### PR TITLE
fix: Show modal routing

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -110,7 +110,15 @@ class App extends Component {
                       {pathname === "/" && <Redirect to="/sets" />}
                       {/* AB: Make this relate to drawer items? */}
                       <Switch>
-                        <Route path="/sets" component={LoadableSetsContainer} />
+                        <Route
+                          exact
+                          path="/sets"
+                          component={LoadableSetsContainer}
+                        />
+                        <Route
+                          path="/sets/:setId"
+                          component={LoadableSetsContainer}
+                        />
                         <Route
                           path="/sets_groups"
                           component={LoadableSetsGroupsContainer}

--- a/src/components/Sets/Set/Tabs.js
+++ b/src/components/Sets/Set/Tabs.js
@@ -1,6 +1,5 @@
-import { Link, withRouter, useRouteMatch } from "react-router-dom";
+import { Link, withRouter } from "react-router-dom";
 import { Tab, Tabs } from "@material-ui/core";
-
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { makeStyles } from "@material-ui/styles";
@@ -16,8 +15,6 @@ const useStyles = makeStyles(theme => ({
 
 function SetTabs(props) {
   const { activeTab, match } = props;
-  const routeMatch = useRouteMatch("/sets/:setId");
-  const setId = routeMatch && (routeMatch.params || {}).setId;
   const classes = useStyles();
   const { t } = useTranslation();
 
@@ -32,17 +29,17 @@ function SetTabs(props) {
       <Tab
         label={t("set.tabs.currentLevel")}
         component={Link}
-        to={`${match.url}/${setId}/current_level`}
+        to={`${match.url}/current_level`}
       />
       <Tab
         label={t("set.tabs.children")}
         component={Link}
-        to={`${match.url}/${setId}/children`}
+        to={`${match.url}/children`}
       />
       <Tab
         label={t("set.tabs.setFormulas")}
         component={Link}
-        to={`${match.url}/${setId}/set_formulas`}
+        to={`${match.url}/set_formulas`}
       />
     </Tabs>
   );

--- a/src/containers/SetContainer/index.js
+++ b/src/containers/SetContainer/index.js
@@ -3,7 +3,6 @@ import { Typography, Dialog, Slide } from "@material-ui/core";
 import {
   useHistory,
   useLocation,
-  useRouteMatch,
   withRouter,
   Route,
   Switch,
@@ -33,10 +32,6 @@ const useStyles = makeStyles(() => ({
 }));
 
 const SetContainer = props => {
-  const routeMatch = useRouteMatch("/sets/:setId");
-  const setId = routeMatch && (routeMatch.params || {}).setId;
-  const open = !!setId;
-
   const classes = useStyles(props);
   const history = useHistory();
   const location = useLocation();
@@ -44,6 +39,8 @@ const SetContainer = props => {
   const [sideSheetOpen, setSideSheetOpen] = useState(false);
 
   const {
+    setId,
+    open,
     set: { name },
     match,
   } = props;
@@ -80,15 +77,15 @@ const SetContainer = props => {
       </TopBar>
       <Switch>
         <Route
-          path={`${match.url}/${setId}/current_level`}
+          path={`${match.url}/current_level`}
           component={SetCurrentLevelContainer}
         />
         <Route
-          path={`${match.url}/${setId}/children`}
+          path={`${match.url}/children`}
           component={SetChildrenContainer}
         />
         <Route
-          path={`${match.url}/${setId}/set_formulas`}
+          path={`${match.url}/set_formulas`}
           component={SetFormulasContainer}
         />
       </Switch>

--- a/src/containers/SetsContainer/index.js
+++ b/src/containers/SetsContainer/index.js
@@ -5,6 +5,7 @@ import { connect } from "react-redux";
 import { useTranslation } from "react-i18next";
 import { InfoBox } from "@blsq/manager-ui";
 import PropTypes from "prop-types";
+import { useParams } from "react-router-dom";
 import PageContent from "../../components/Shared/PageContent";
 import TopBar from "../../components/Shared/TopBar";
 import SetList from "../../components/Sets/SetList";
@@ -20,7 +21,8 @@ const SetsContainer = props => {
   const [sideSheetOpen, setSideSheetOpen] = useState(false);
   const [searchOpen, setSearchOpen] = useState(false);
   const [query, setQuery] = useState("");
-
+  const { setId } = useParams();
+  const modalOpen = !!setId;
   const handleToggleSideSheet = () => setSideSheetOpen(!sideSheetOpen);
   const handleToggleSearch = () => setSearchOpen(!searchOpen);
 
@@ -62,7 +64,7 @@ const SetsContainer = props => {
           {t("sets.index.infoBox")}
         </InfoBox>
         <SetList sets={filteredSets} noItems={!props.sets.length} />
-        <SetContainer />
+        <SetContainer open={modalOpen} setId={setId} />
       </PageContent>
       <SideSheet
         title={t("filtersSheet.title")}


### PR DESCRIPTION
By making the base routes render the same component, we can get the setId early on and pass it as props to children, avoid subsequent use of manual params catching