### PR TITLE
refactor: Move Simulations to functional components

### DIFF
--- a/src/components/Shared/MultiSelectDropdown.js
+++ b/src/components/Shared/MultiSelectDropdown.js
@@ -33,7 +33,7 @@ const styles = theme => ({
   },
   chip: {
     fontSize: 12,
-    margin: theme.spacing(1/10),
+    margin: theme.spacing(1 / 10),
   },
   noLabel: {
     marginTop: theme.spacing(3),

--- a/src/components/Shared/MultiSelectDropdown.js
+++ b/src/components/Shared/MultiSelectDropdown.js
@@ -21,7 +21,7 @@ const styles = theme => ({
   formControl: {
     display: "flex",
     flexWrap: "wrap",
-    margin: theme.spacing.unit,
+    margin: theme.spacing(1),
     minWidth: 250,
     maxWidth: 320,
   },
@@ -33,10 +33,10 @@ const styles = theme => ({
   },
   chip: {
     fontSize: 12,
-    margin: theme.spacing.unit / 10,
+    margin: theme.spacing(1/10),
   },
   noLabel: {
-    marginTop: theme.spacing.unit * 3,
+    marginTop: theme.spacing(3),
   },
 });
 

--- a/src/components/Simulation/Header.js
+++ b/src/components/Simulation/Header.js
@@ -10,7 +10,7 @@ const Header = function(props) {
   const name = props.invoice.code;
   const classes = useStyles(props);
   return (
-    <Fragment
+    <div
       data-period={props.invoice.period}
       data-orgunit={props.invoice.orgunit_ext_id}
       data-code={props.invoice.code}
@@ -23,7 +23,7 @@ const Header = function(props) {
       >
         {humanize(name)}
       </Typography>
-    </Fragment>
+    </div>
   );
 };
 

--- a/src/components/Simulation/Header.js
+++ b/src/components/Simulation/Header.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from "react";
+import React from "react";
 import humanize from "string-humanize";
 import { Typography } from "@material-ui/core";
 import { makeStyles } from "@material-ui/styles";

--- a/src/components/Simulation/SimulationPart.js
+++ b/src/components/Simulation/SimulationPart.js
@@ -1,0 +1,41 @@
+import { Grid, withStyles } from "@material-ui/core";
+import React, { Fragment } from "react";
+import { connect } from "react-redux";
+import { withTranslation } from "react-i18next";
+import Table from "./Table/table";
+import SimulationHeader from "./Header";
+import { KeyNumberBlock } from "@blsq/manager-ui";
+import humanize from "string-humanize";
+
+const styles = theme => ({
+  header: {
+    padding: "5px",
+  },
+});
+
+export const SimulationPart = props => {
+  const { simulation } = props;
+
+  return (
+    <Fragment>
+      <SimulationHeader key="header" invoice={simulation} />
+      <Grid container item xs={12} spacing={3}>
+        {simulation.total_items.map(item => (
+          <Grid item xs={3}>
+            <KeyNumberBlock
+              text={humanize(item.formula)}
+              value={item.solution}
+            />
+          </Grid>
+        ))}
+      </Grid>
+      <Table key="invoice" invoice={simulation} />
+    </Fragment>
+  );
+};
+
+const mapStateToProps = state => ({});
+
+export default withTranslation("translations")(
+  withStyles(styles)(connect(mapStateToProps)(SimulationPart)),
+);

--- a/src/components/Simulation/index.js
+++ b/src/components/Simulation/index.js
@@ -1,45 +1,93 @@
-import { Grid, withStyles } from "@material-ui/core";
-import React, { Fragment } from "react";
-import { connect } from "react-redux";
-import { withTranslation } from "react-i18next";
-import Table from "./Table/table";
-import PropTypes from "prop-types";
-import Header from "./Header";
-import { KeyNumberBlock } from "@blsq/manager-ui";
-import humanize from "string-humanize";
+import {
+  Dialog,
+  Typography,
+  Slide,
+  Fade,
+  makeStyles,
+} from "@material-ui/core";
+import Snackbar from "@material-ui/core/Snackbar";
+import LinearProgress from "@material-ui/core/LinearProgress";
 
-const styles = theme => ({
-  header: {
-    padding: "5px",
+import React from "react";
+import PropTypes from "prop-types";
+import TopBar from "../Shared/TopBar";
+import FiltersToggleBtn from "../FiltersToggleBtn";
+import SimulationList from "./list";
+
+const styles = makeStyles(theme => ({
+  infoBox: {
+    marginBottom: theme.spacing(4),
   },
+  appBarHeader: {
+    flex: 1,
+  },
+  filtersBtn: {
+    marginLeft: theme.spacing(1),
+  },
+}));
+
+const Transition = React.forwardRef(function Transition(props, ref) {
+  return <Slide direction="up" ref={ref} {...props} />;
 });
 
 export const Simulation = props => {
-  const { simulation } = props;
+  const classes = styles();
+  const { errorMessage, loading, payload, history, simulationData } = props;
+
+  const isLoaded = !loading;
+  const hasError = !!errorMessage;
+  const isSuccess = isLoaded && !hasError;
+  const open = simulationData && !!simulationData.id;
+
+  const name = simulationData && simulationData.name;
+  const formattedDate = simulationData && simulationData.period;
+  const nameWithDate = `${name}-${formattedDate}`;
+
   return (
-    <Fragment>
-      <Header key="header" invoice={simulation} />
-      <Grid container item xs={12} spacing={3}>
-        {simulation.total_items.map(item => (
-          <Grid item xs={3}>
-            <KeyNumberBlock
-              text={humanize(item.formula)}
-              value={item.solution}
-            />
-          </Grid>
-        ))}
-      </Grid>
-      <Table key="invoice" invoice={simulation} />
-    </Fragment>
+    <Dialog
+      fullScreen
+      open={open}
+      className={classes.root}
+      onClose={() => history.push("/simulations")}
+      TransitionComponent={Transition}
+    >
+      <TopBar fullscreen backLinkPath="/simulations">
+        <Typography
+          variant="h6"
+          color="inherit"
+          className={classes.appBarHeader}
+        >
+          {nameWithDate}
+        </Typography>
+        <FiltersToggleBtn variant="info" className={classes.filtersBtn} />
+      </TopBar>
+      <Fade in={loading} unmountOnExit>
+        <LinearProgress variant="query" />
+      </Fade>
+      <Snackbar
+        anchorOrigin={{ vertical: "top", horizontal: "right" }}
+        open={isLoaded && hasError}
+        autoHideDuration={6000}
+        message={<span id="message-id">Error: {errorMessage}</span>}
+      />
+      {isSuccess && (
+        <SimulationList key="list" simulations={payload.invoices} />
+      )}
+    </Dialog>
   );
 };
 
 Simulation.propTypes = {
-  simulation: PropTypes.any,
+  errorMessage: PropTypes.string,
+  loading: PropTypes.bool,
+  payload: PropTypes.shape({
+    invoices: PropTypes.array,
+  }),
+  simulation: PropTypes.shape({
+    id: PropTypes.string,
+    name: PropTypes.string,
+    period: PropTypes.string,
+  }),
 };
 
-const mapStateToProps = state => ({});
-
-export default withTranslation("translations")(
-  withStyles(styles)(connect(mapStateToProps)(Simulation)),
-);
+export default Simulation;

--- a/src/components/Simulation/index.js
+++ b/src/components/Simulation/index.js
@@ -1,10 +1,4 @@
-import {
-  Dialog,
-  Typography,
-  Slide,
-  Fade,
-  makeStyles,
-} from "@material-ui/core";
+import { Dialog, Typography, Slide, Fade, makeStyles } from "@material-ui/core";
 import Snackbar from "@material-ui/core/Snackbar";
 import LinearProgress from "@material-ui/core/LinearProgress";
 

--- a/src/components/Simulation/list.js
+++ b/src/components/Simulation/list.js
@@ -56,11 +56,6 @@ const SimulationList = props => {
   if (periods.length < 1 && allPeriods.length > 0) setPeriods(allPeriods);
   if (packages.length < 1 && allPackages.length > 0) setPackages(allPackages);
 
-
-  const name = (simulations[0] || {code: ""}).code;
-  const formatted_date = (simulations[0] || {period: ""}).period;
-  const nameWithDate = `${name}-${formatted_date}`;
-
   const filteredSimulations = simulations.filter(simulation => {
     return (
       some(periods, ["key", simulation.period]) &&
@@ -92,11 +87,6 @@ const SimulationList = props => {
 
   return (
       <Fragment>
-        <TopBar>
-          <Typography variant="h6" color="inherit">
-            {nameWithDate}
-          </Typography>
-        </TopBar>
         <PageContent>
           <Grid container spacing={4}>
             <Grid item xs={12} lg={8}>

--- a/src/components/Simulation/list.js
+++ b/src/components/Simulation/list.js
@@ -1,5 +1,5 @@
 import { Grid, withStyles, Typography } from "@material-ui/core";
-import React, { Fragment } from "react";
+import React, { useState, Fragment } from "react";
 import { connect } from "react-redux";
 import { withTranslation } from "react-i18next";
 import humanize from "string-humanize";
@@ -39,65 +39,58 @@ const mapOrgunits = invoices => {
   return uniqWith(all, (a, b) => a.key === b.key);
 };
 
-class SimulationList extends React.Component {
-  constructor(props) {
-    super(props);
-    const periods = mapPeriods(props.simulations);
-    const packages = mapPackages(props.simulations);
-    const orgunits = mapOrgunits(props.simulations);
-    this.state = {
-      periods,
-      allPeriods: periods,
-      packages,
-      allPackages: packages,
-      orgUnits: [orgunits[0]],
-      allOrgUnits: orgunits,
-    };
+const SimulationList = props => {
+  const { simulations } = props;
+  const allPeriods = mapPeriods(simulations);
+  const allPackages = mapPackages(simulations);
+  const allOrgUnits = mapOrgunits(simulations);
+
+  const [periods, setPeriods] = useState([]);
+  const [packages, setPackages] = useState([]);
+  const [orgUnits, setOrgUnits] = useState([]);
+
+  // Set default selection
+  if (orgUnits.length < 1 && allOrgUnits.length > 0) {
+    setOrgUnits([allOrgUnits[0]]);
   }
+  if (periods.length < 1 && allPeriods.length > 0) setPeriods(allPeriods);
+  if (packages.length < 1 && allPackages.length > 0) setPackages(allPackages);
 
-  periodsChanged = periodKeys => {
-    const selectedPeriods = this.state.allPeriods.filter(item =>
-      periodKeys.includes(item.key),
-    );
-    this.setState({ periods: selectedPeriods });
-  };
 
-  packagesChanged = packageKeys => {
-    const selectedPackages = this.state.allPackages.filter(item =>
-      packageKeys.includes(item.key),
-    );
-    this.setState({ packages: selectedPackages });
-  };
+  const name = (simulations[0] || {code: ""}).code;
+  const formatted_date = (simulations[0] || {period: ""}).period;
+  const nameWithDate = `${name}-${formatted_date}`;
 
-  orgUnitsChanged = orgUnitKeys => {
-    const selectedOrgUnits = this.state.allOrgUnits.filter(item =>
-      orgUnitKeys.includes(item.key),
-    );
-    this.setState({ orgUnits: selectedOrgUnits });
-  };
-
-  render() {
-    const {
-      allPeriods,
-      periods,
-      allPackages,
-      packages,
-      allOrgUnits,
-      orgUnits,
-    } = this.state;
-
-    const { simulations } = this.props;
-    const name = simulations[0].code;
-    const formatted_date = simulations[0].period;
-    const nameWithDate = `${name}-${formatted_date}`;
-    const filteredSimulations = simulations.filter(simulation => {
-      return (
-        some(periods, ["key", simulation.period]) &&
+  const filteredSimulations = simulations.filter(simulation => {
+    return (
+      some(periods, ["key", simulation.period]) &&
         some(packages, ["key", simulation.code]) &&
         some(orgUnits, ["key", simulation.orgunit_ext_id])
-      );
-    });
-    return (
+    );
+  });
+
+  const periodsChanged = periodKeys => {
+    const selectedPeriods = allPeriods.filter(item =>
+      periodKeys.includes(item.key),
+    );
+    setPeriods(selectedPeriods);
+  };
+
+  const packagesChanged = packageKeys => {
+    const selectedPackages = allPackages.filter(item =>
+      packageKeys.includes(item.key),
+    );
+    setPackages(selectedPackages);
+  };
+
+  const orgUnitsChanged = orgUnitKeys => {
+    const selectedOrgUnits = allOrgUnits.filter(item =>
+      orgUnitKeys.includes(item.key),
+    );
+    setOrgUnits(selectedOrgUnits);
+  };
+
+  return (
       <Fragment>
         <TopBar>
           <Typography variant="h6" color="inherit">
@@ -118,21 +111,21 @@ class SimulationList extends React.Component {
                   name="Periods"
                   items={allPeriods}
                   selected={periods}
-                  optionsChanged={this.periodsChanged}
+                  optionsChanged={periodsChanged}
                   key="periods"
                 />
                 <MultiSelectDropdown
                   name="Org Units"
                   items={allOrgUnits}
                   selected={orgUnits}
-                  optionsChanged={this.orgUnitsChanged}
+                  optionsChanged={orgUnitsChanged}
                   key="orgUnits"
                 />
                 <MultiSelectDropdown
                   name="Packages"
                   items={allPackages}
                   selected={packages}
-                  optionsChanged={this.packagesChanged}
+                  optionsChanged={packagesChanged}
                   key="packages"
                 />
               </Grid>
@@ -148,9 +141,8 @@ class SimulationList extends React.Component {
           </Grid>
         </PageContent>
       </Fragment>
-    );
-  }
-}
+  );
+};
 
 const mapStateToProps = state => ({});
 SimulationList.propTypes = {

--- a/src/components/Simulation/list.js
+++ b/src/components/Simulation/list.js
@@ -7,7 +7,7 @@ import PropTypes from "prop-types";
 import some from "lodash/some";
 import uniqWith from "lodash/uniqWith";
 import MultiSelectDropdown from "../Shared/MultiSelectDropdown";
-import { Simulation } from "./index";
+import { SimulationPart } from "./SimulationPart";
 import TopBar from "../Shared/TopBar";
 import PageContent from "../Shared/PageContent";
 
@@ -125,7 +125,7 @@ const SimulationList = props => {
                   simulation.period,
                   simulation.code,
                 ].join("-");
-                return <Simulation key={key} simulation={simulation} />;
+                return <SimulationPart key={key} simulation={simulation} />;
               })}
             </Grid>
           </Grid>

--- a/src/components/Simulation/list.js
+++ b/src/components/Simulation/list.js
@@ -59,8 +59,8 @@ const SimulationList = props => {
   const filteredSimulations = simulations.filter(simulation => {
     return (
       some(periods, ["key", simulation.period]) &&
-        some(packages, ["key", simulation.code]) &&
-        some(orgUnits, ["key", simulation.orgunit_ext_id])
+      some(packages, ["key", simulation.code]) &&
+      some(orgUnits, ["key", simulation.orgunit_ext_id])
     );
   });
 
@@ -86,51 +86,51 @@ const SimulationList = props => {
   };
 
   return (
-      <Fragment>
-        <PageContent>
-          <Grid container spacing={4}>
-            <Grid item xs={12} lg={8}>
-              <Grid
-                container
-                key="selection-grid"
-                direction="row"
-                justify="space-between"
-                alignItems="flex-start"
-              >
-                <MultiSelectDropdown
-                  name="Periods"
-                  items={allPeriods}
-                  selected={periods}
-                  optionsChanged={periodsChanged}
-                  key="periods"
-                />
-                <MultiSelectDropdown
-                  name="Org Units"
-                  items={allOrgUnits}
-                  selected={orgUnits}
-                  optionsChanged={orgUnitsChanged}
-                  key="orgUnits"
-                />
-                <MultiSelectDropdown
-                  name="Packages"
-                  items={allPackages}
-                  selected={packages}
-                  optionsChanged={packagesChanged}
-                  key="packages"
-                />
-              </Grid>
-              {filteredSimulations.map((simulation, i) => {
-                const key = [
-                  simulation.orgunit_ext_id,
-                  simulation.period,
-                  simulation.code,
-                ].join("-");
-                return <SimulationPart key={key} simulation={simulation} />;
-              })}
+    <Fragment>
+      <PageContent>
+        <Grid container spacing={4}>
+          <Grid item xs={12} lg={8}>
+            <Grid
+              container
+              key="selection-grid"
+              direction="row"
+              justify="space-between"
+              alignItems="flex-start"
+            >
+              <MultiSelectDropdown
+                name="Periods"
+                items={allPeriods}
+                selected={periods}
+                optionsChanged={periodsChanged}
+                key="periods"
+              />
+              <MultiSelectDropdown
+                name="Org Units"
+                items={allOrgUnits}
+                selected={orgUnits}
+                optionsChanged={orgUnitsChanged}
+                key="orgUnits"
+              />
+              <MultiSelectDropdown
+                name="Packages"
+                items={allPackages}
+                selected={packages}
+                optionsChanged={packagesChanged}
+                key="packages"
+              />
             </Grid>
+            {filteredSimulations.map((simulation, i) => {
+              const key = [
+                simulation.orgunit_ext_id,
+                simulation.period,
+                simulation.code,
+              ].join("-");
+              return <SimulationPart key={key} simulation={simulation} />;
+            })}
           </Grid>
-        </PageContent>
-      </Fragment>
+        </Grid>
+      </PageContent>
+    </Fragment>
   );
 };
 

--- a/src/components/Simulation/list.js
+++ b/src/components/Simulation/list.js
@@ -1,4 +1,4 @@
-import { Grid, withStyles, Typography } from "@material-ui/core";
+import { Grid, withStyles } from "@material-ui/core";
 import React, { useState, Fragment } from "react";
 import { connect } from "react-redux";
 import { withTranslation } from "react-i18next";
@@ -8,7 +8,6 @@ import some from "lodash/some";
 import uniqWith from "lodash/uniqWith";
 import MultiSelectDropdown from "../Shared/MultiSelectDropdown";
 import { SimulationPart } from "./SimulationPart";
-import TopBar from "../Shared/TopBar";
 import PageContent from "../Shared/PageContent";
 
 const styles = theme => ({});

--- a/src/components/Simulations/SimulationListItem/index.js
+++ b/src/components/Simulations/SimulationListItem/index.js
@@ -57,7 +57,7 @@ const SimulationListItem = props => {
 };
 
 SimulationListItem.propTypes = {
-  buildDuration: PropTypes.string,
+  buildDuration: PropTypes.number,
   createdAt: PropTypes.string,
   groups: PropTypes.array,
   id: PropTypes.string,

--- a/src/containers/SimulationContainer/index.js
+++ b/src/containers/SimulationContainer/index.js
@@ -33,6 +33,10 @@ const SimulationContainer = props => {
   const simulationId = routeMatch && (routeMatch.params || {}).simulationId;
   const open = !!simulationId;
 
+  const name = props.simulation.name;
+  const formattedDate = props.simulation.period;
+  const nameWithDate = `${name}-${formattedDate}`;
+
   useEffect(() => {
     const url = "http://localhost:4567/api/simulations/1234";
     if (!timer.current) {
@@ -109,7 +113,7 @@ const SimulationContainer = props => {
           color="inherit"
           className={classes.appBarHeader}
         >
-          {set.name}
+          {nameWithDate}
         </Typography>
         <FiltersToggleBtn variant="info" className={classes.filtersBtn} />
       </TopBar>
@@ -130,7 +134,7 @@ const SimulationContainer = props => {
 };
 
 const mapStateToProps = () => ({
-  set: {
+  simulation: {
     id: "1234",
     name: "SIGL BCZ FOSA Coherence, COSPRO - A.3 - Bureaux Administratifs",
     groupNames: ["BCZs"],

--- a/src/containers/SimulationContainer/index.js
+++ b/src/containers/SimulationContainer/index.js
@@ -1,4 +1,3 @@
-import Fade from "@material-ui/core/Fade";
 import { connect } from "react-redux";
 import React, { useState, useEffect, useRef } from "react";
 import { withRouter, matchPath } from "react-router-dom";
@@ -12,14 +11,13 @@ const SimulationContainer = props => {
   const [jsonPayload, setJsonPayload] = useState({ invoices: [] });
   const timer = useRef(null);
 
-  const { classes, history, set, location } = props;
+  const { location } = props;
   const routeMatch = matchPath(location.pathname, {
     path: "/simulations/:simulationId",
     exact: true,
     strict: false,
   });
   const simulationId = routeMatch && (routeMatch.params || {}).simulationId;
-  const open = !!simulationId;
   const simulationData = {
     id: simulationId,
     name: props.simulation.name,

--- a/src/containers/SimulationContainer/index.js
+++ b/src/containers/SimulationContainer/index.js
@@ -1,19 +1,10 @@
-import LinearProgress from "@material-ui/core/LinearProgress";
 import Fade from "@material-ui/core/Fade";
 import { connect } from "react-redux";
 import React, { useState, useEffect, useRef } from "react";
-import Snackbar from "@material-ui/core/Snackbar";
-import SimulationList from "../../components/Simulation/list";
-import { Dialog, Typography, Slide } from "@material-ui/core";
 import { withRouter, matchPath } from "react-router-dom";
-import TopBar from "../../components/Shared/TopBar";
-import FiltersToggleBtn from "../../components/FiltersToggleBtn";
 import { withStyles } from "@material-ui/styles";
 import styles from "./styles";
-
-const Transition = React.forwardRef(function Transition(props, ref) {
-  return <Slide direction="up" ref={ref} {...props} />;
-});
+import Simulation from "../../components/Simulation";
 
 const SimulationContainer = props => {
   const [loading, setLoading] = useState(true);
@@ -21,9 +12,6 @@ const SimulationContainer = props => {
   const [jsonPayload, setJsonPayload] = useState({ invoices: [] });
   const timer = useRef(null);
 
-  const isLoaded = !loading;
-  const hasError = !!errorMessage;
-  const isSuccess = isLoaded && !hasError;
   const { classes, history, set, location } = props;
   const routeMatch = matchPath(location.pathname, {
     path: "/simulations/:simulationId",
@@ -32,10 +20,11 @@ const SimulationContainer = props => {
   });
   const simulationId = routeMatch && (routeMatch.params || {}).simulationId;
   const open = !!simulationId;
-
-  const name = props.simulation.name;
-  const formattedDate = props.simulation.period;
-  const nameWithDate = `${name}-${formattedDate}`;
+  const simulationData = {
+    id: simulationId,
+    name: props.simulation.name,
+    period: props.simulation.period,
+  };
 
   useEffect(() => {
     const url = "http://localhost:4567/api/simulations/1234";
@@ -48,7 +37,7 @@ const SimulationContainer = props => {
     };
   });
 
-  const fetchJSON = async (url) => {
+  const fetchJSON = async url => {
     try {
       const response = await fetch(url, {});
       const json = await response.json();
@@ -58,7 +47,7 @@ const SimulationContainer = props => {
     }
   };
 
-  const apiFetch = async (url) =>  {
+  const apiFetch = async url => {
     const response = await fetchJSON(url);
     if (response.success) {
       const {
@@ -84,7 +73,7 @@ const SimulationContainer = props => {
     }
   };
 
-  const fetchSimulationResult = async (url) => {
+  const fetchSimulationResult = async url => {
     const response = await fetchJSON(url);
     if (response.success) {
       setLoading(false);
@@ -100,39 +89,14 @@ const SimulationContainer = props => {
   };
 
   return (
-    <Dialog
-      fullScreen
-      open={open}
-      className={classes.root}
-      onClose={() => history.push("/simulations")}
-      TransitionComponent={Transition}
-    >
-      <TopBar fullscreen backLinkPath="/simulations">
-        <Typography
-          variant="h6"
-          color="inherit"
-          className={classes.appBarHeader}
-        >
-          {nameWithDate}
-        </Typography>
-        <FiltersToggleBtn variant="info" className={classes.filtersBtn} />
-      </TopBar>
-      <Fade in={loading} unmountOnExit>
-        <LinearProgress variant="query" />
-      </Fade>
-      <Snackbar
-        anchorOrigin={{ vertical: "top", horizontal: "right" }}
-        open={isLoaded && hasError}
-        autoHideDuration={6000}
-        message={<span id="message-id">Error: {errorMessage}</span>}
-      />
-      {isSuccess && (
-        <SimulationList key="list" simulations={jsonPayload.invoices} />
-      )}
-    </Dialog>
+    <Simulation
+      errorMessage={errorMessage}
+      loading={loading}
+      payload={jsonPayload}
+      simulationData={simulationData}
+    />
   );
 };
-
 const mapStateToProps = () => ({
   simulation: {
     id: "1234",


### PR DESCRIPTION
This transforms the simulation container into a functional component (so that it's more in line with the others and that I can use the same route logic as in the sets)

It also transforms the simulation overview to be a functional component because I was getting warnings in react about using deprecated functions.