### PR TITLE
fix: Typo in translation for buttons.back

### DIFF
--- a/src/components/Shared/TopBar.js
+++ b/src/components/Shared/TopBar.js
@@ -50,7 +50,7 @@ function TopBar(props) {
             component={Link}
             to={props.backLinkPath}
             color="inherit"
-            aria-label={t("button.back")}
+            aria-label={t("buttons.back")}
           >
             <BackIcon />
           </IconButton>


### PR DESCRIPTION
Really, really small fix for a warning I saw popup.