### PR TITLE
Add `simulations` endpoint and direct link for simulations

### DIFF
--- a/mock-server/README.md
+++ b/mock-server/README.md
@@ -10,8 +10,8 @@ You can access using simulation id (which is unique):
 
 Or you can access them by referencing the `org_unit` and `period` directly, which will not always return the exact same simulation instance, but will always return the simulation for that period and org unit. (So the ID one is stuck in time, this one is always the most recently ran one.)
 
-`/api/simulations/AOsKyLAjVWH?periods=2016Q1` => Normal result
-`/api/simulations/BOsKyLAjVWH?periods=2019Q2` => Normal result
-`/api/simulations/COsKyLAjVWH?periods=2018Q1` => Error: Could not connect to DHIS2
+`/api/simulation?orgUnit=AOsKyLAjVWH&periods=2016Q1` => Normal result
+`/api/simulation?orgUnit=BOsKyLAjVWH&periods=2019Q2` => Normal result
+`/api/simulation?orgUnit=COsKyLAjVWH&periods=2018Q1` => Error: Could not connect to DHIS2
 
 If you try and fetch an org unit with a period that's not run, you'll get a 404.

--- a/mock-server/README.md
+++ b/mock-server/README.md
@@ -1,4 +1,17 @@
 
+
+`/api/simulations`   => Returns all ran simulations
+
+You can access using simulation id (which is unique):
+
 `/api/simulations/1` => Normal result
 `/api/simulations/2` => Normal result (but different period)
-`/api/simulations/3` => Error: Could not connect do DHIS2
+`/api/simulations/3` => Error: Could not connect to DHIS2
+
+Or you can access them by referencing the `org_unit` and `period` directly, which will not always return the exact same simulation instance, but will always return the simulation for that period and org unit. (So the ID one is stuck in time, this one is always the most recently ran one.)
+
+`/api/simulations/AOsKyLAjVWH?periods=2016Q1` => Normal result
+`/api/simulations/BOsKyLAjVWH?periods=2019Q2` => Normal result
+`/api/simulations/COsKyLAjVWH?periods=2018Q1` => Error: Could not connect to DHIS2
+
+If you try and fetch an org unit with a period that's not run, you'll get a 404.

--- a/mock-server/app.rb
+++ b/mock-server/app.rb
@@ -1,6 +1,22 @@
 # myapp.rb
 require 'sinatra'
 
+def simulation_id_based_on_org_unit_and_period(org_unit, period)
+  all = JSON.parse(File.read("data/simulations.json"))
+  response = all["data"].detect do |h|
+    puts h
+    puts h["attributes"]["orgUnit"]
+    puts h["attributes"]["dhis2Period"]
+    h["attributes"]["orgUnit"] == org_unit &&
+      h["attributes"]["dhis2Period"] == period
+  end
+  if response
+    response["id"]
+  else
+    nil
+  end
+end
+
 before do
   response.headers['Access-Control-Allow-Origin'] = '*'
 end
@@ -9,9 +25,27 @@ get '/' do
   'Hello world!'
 end
 
-get '/api/simulations/:identifier' do |identifier|
-  puts identifier
+get '/api/simulations' do
   content_type :json
+  File.read("data/simulations.json")
+end
+
+# This needs a ?periods to be set.
+get %r{/api/simulations/([A-za-z]+)} do |org_unit|
+  content_type :json
+  period = params[:periods].split(",").first
+  identifier = simulation_id_based_on_org_unit_and_period(org_unit, period)
+
+  if identifier && path = Dir.glob("data/*#{identifier}.json").first
+    File.read(path)
+  else
+    not_found
+  end
+end
+
+get %r{/api/simulations/([0-9]+)} do |identifier|
+  content_type :json
+  periods = params[:periods]
   if path = Dir.glob("data/*#{identifier}.json").first
     File.read(path)
   else

--- a/mock-server/app.rb
+++ b/mock-server/app.rb
@@ -30,9 +30,11 @@ get '/api/simulations' do
   File.read("data/simulations.json")
 end
 
-# This needs a ?periods to be set.
-get %r{/api/simulations/([A-za-z]+)} do |org_unit|
-  content_type :json
+# Filter to a specific simulation
+#
+# Needs ?orgUnit=bla&periods=2019Q1
+get '/api/simulation' do
+  org_unit = params[:orgUnit] || ""
   period = params[:periods].split(",").first
   identifier = simulation_id_based_on_org_unit_and_period(org_unit, period)
 

--- a/mock-server/data/simulations.json
+++ b/mock-server/data/simulations.json
@@ -1,0 +1,58 @@
+{
+  "data": [
+    {
+      "id": "1",
+      "type": "invoicingJob",
+      "attributes": {
+        "orgUnit": "AOsKyLAjVWH",
+        "dhis2Period": "2016Q1",
+        "user": null,
+        "createdAt": "2019-11-21T08:51:41.010Z",
+        "processedAt": "2019-11-21T08:51:43.922Z",
+        "erroredAt": null,
+        "durationMs": 2872,
+        "status": "processed",
+        "lastError": null,
+        "sidekiqJobRef": null,
+        "isAlive": false,
+        "resultUrl": "http://localhost:4567/s3/results/1.json"
+      }
+    },
+    {
+      "id": "2",
+      "type": "invoicingJob",
+      "attributes": {
+        "orgUnit": "BOsKyLAjVWH",
+        "dhis2Period": "2019Q2",
+        "user": null,
+        "createdAt": "2019-11-21T08:51:41.010Z",
+        "processedAt": "2019-11-21T08:51:43.922Z",
+        "erroredAt": null,
+        "durationMs": 2872,
+        "status": "processed",
+        "lastError": null,
+        "sidekiqJobRef": null,
+        "isAlive": false,
+        "resultUrl": "http://localhost:4567/s3/results/2.json"
+      }
+    },
+    {
+      "id": "3",
+      "type": "invoicingJob",
+      "attributes": {
+        "orgUnit": "COsKyLAjVWH",
+        "dhis2Period": "2018Q1",
+        "user": null,
+        "createdAt": "2019-11-21T08:51:41.010Z",
+        "processedAt": null,
+        "erroredAt": "2019-11-21T08:51:43.922Z",
+        "durationMs": 2872,
+        "status": "processed",
+        "lastError": "Failed to open TCP connection to dhis.example.com:80 (getaddrinfo: nodename nor servname provided, or not known)",
+        "sidekiqJobRef": null,
+        "isAlive": false,
+        "resultUrl": null
+      }
+    }
+  ]
+}


### PR DESCRIPTION
`/api/simulations`   => Returns all ran simulations

You can access using simulation id (which is unique):

`/api/simulations/1` => Normal result
`/api/simulations/2` => Normal result (but different period)
`/api/simulations/3` => Error: Could not connect to DHIS2

Or you can access them by referencing the `org_unit` and `period` directly, which will not always return the exact same simulation instance, but will always return the simulation for that period and org unit. (So the ID one is stuck in time, this one is always the most recently ran one.)

`/api/simulations/AOsKyLAjVWH?periods=2016Q1` => Normal result
`/api/simulations/BOsKyLAjVWH?periods=2019Q2` => Normal result
`/api/simulations/COsKyLAjVWH?periods=2018Q1` => Error: Could not connect to DHIS2

If you try and fetch an org unit with a period that's not run, you'll get a 404.