### PR TITLE
Autocomplete endpoint

### DIFF
--- a/mock-server/README.md
+++ b/mock-server/README.md
@@ -15,3 +15,7 @@ Or you can access them by referencing the `org_unit` and `period` directly, whic
 `/api/simulation?orgUnit=COsKyLAjVWH&periods=2018Q1` => Error: Could not connect to DHIS2
 
 If you try and fetch an org unit with a period that's not run, you'll get a 404.
+
+`/api/org_units` => Returns all org units
+`/api/org_units?term=arab` => returns all org units matching that term
+`/api/org_units?id=Rp268JB6Ne4` => returns all org units matching that id

--- a/mock-server/app.rb
+++ b/mock-server/app.rb
@@ -63,3 +63,23 @@ get '/s3/results/:identifier.json' do |identifier|
     not_found
   end
 end
+
+# Without a term will return all known org units
+# With a ?term will filter on name
+# With a ?id will filter on id
+get '/api/org_units' do
+  content_type :json
+  all_json = File.read("data/all_orgunits.json")
+  if id = params[:id]
+    units = JSON.parse(all_json)["data"]
+    units = units.select {|h| h["id"] == id }
+    {data: units}.to_json
+  elsif term = params[:term]
+    units = JSON.parse(all_json)["data"]
+    units = units.select {|h| h["attributes"]["displayName"].downcase.include?(term.downcase) }
+    {data: units}.to_json
+  else
+    all_json
+  end
+
+end

--- a/mock-server/data/all_orgunits.json
+++ b/mock-server/data/all_orgunits.json
@@ -1,0 +1,921 @@
+{
+  "data": [
+    {
+      "id": "Rp268JB6Ne4",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Adonkia CHP"
+      }
+    },
+    {
+      "id": "cDw53Ej8rju",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Afro Arab Clinic"
+      }
+    },
+    {
+      "id": "GvFqTavdpGE",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Agape CHP"
+      }
+    },
+    {
+      "id": "plnHVbJR6p4",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Ahamadyya Mission Cl"
+      }
+    },
+    {
+      "id": "BV4IomHvri4",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Ahmadiyya Muslim Hospital"
+      }
+    },
+    {
+      "id": "qjboFI0irVu",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Air Port Centre, Lungi"
+      }
+    },
+    {
+      "id": "ENHOJz3UH5L",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "BMC"
+      }
+    },
+    {
+      "id": "r5WWF9WDzoa",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Baama CHC"
+      }
+    },
+    {
+      "id": "yMCshbaVExv",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Babara CHC"
+      }
+    },
+    {
+      "id": "tlMeFk8C4CG",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Badala MCHP"
+      }
+    },
+    {
+      "id": "YuQRtpLP10I",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Badjia"
+      }
+    },
+    {
+      "id": "Jiymtq0A01x",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Bafodia CHC"
+      }
+    },
+    {
+      "id": "KiheEgvUZ0i",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Calaba town CHC"
+      }
+    },
+    {
+      "id": "h9q3qixffZT",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Campbell Town  CHP"
+      }
+    },
+    {
+      "id": "PD1fqyvJssC",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Catholic Clinic"
+      }
+    },
+    {
+      "id": "uYTq3TEO2a9",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Charlotte CHP"
+      }
+    },
+    {
+      "id": "U4FzUXMvbI8",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Conakry Dee CHC"
+      }
+    },
+    {
+      "id": "yTMrs5kClCv",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Condama MCHP"
+      }
+    },
+    {
+      "id": "Xytauldn2QJ",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Dalakuru CHP"
+      }
+    },
+    {
+      "id": "myQ4q1W6B4y",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Dama"
+      }
+    },
+    {
+      "id": "wByqtWCCuDJ",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Damballa CHC"
+      }
+    },
+    {
+      "id": "RpRJUDOPtt7",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Dandabu CHP"
+      }
+    },
+    {
+      "id": "flQBQV8eyHc",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Dankawalia MCHP"
+      }
+    },
+    {
+      "id": "DErmFP7bri7",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Dankawalie MCHP"
+      }
+    },
+    {
+      "id": "K3k64jslIlL",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "EDC Unit CHP"
+      }
+    },
+    {
+      "id": "LaxJ6CD2DHq",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "EM&BEE Maternity Home Clinic"
+      }
+    },
+    {
+      "id": "FO1Tq8vUa62",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "EPI Headquarter"
+      }
+    },
+    {
+      "id": "F7oVR22kQ5J",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Elshadai Clinic"
+      }
+    },
+    {
+      "id": "sK498nBOLfQ",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Elshadai MCHP"
+      }
+    },
+    {
+      "id": "ZpE2POxvl9P",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Faabu CHP"
+      }
+    },
+    {
+      "id": "hKD6hpZUh9v",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Faala CHP"
+      }
+    },
+    {
+      "id": "K6oyIMh7Lee",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Fadugu CHC"
+      }
+    },
+    {
+      "id": "Gm7YUjhVi9Q",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Fairo CHC"
+      }
+    },
+    {
+      "id": "vULnao2hV5v",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Fakunya"
+      }
+    },
+    {
+      "id": "kuqKh33SPgg",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Falaba CHC"
+      }
+    },
+    {
+      "id": "eNtRuQrrZeo",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Galliness Perri"
+      }
+    },
+    {
+      "id": "UWhv0MQOqoB",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Gambia CHP"
+      }
+    },
+    {
+      "id": "ii2KMnWMx2L",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Gandorhun (Gbane) CHC"
+      }
+    },
+    {
+      "id": "ZdPkczYqeIY",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Gandorhun CHC"
+      }
+    },
+    {
+      "id": "IWb1hstfROc",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Gandorhun CHP"
+      }
+    },
+    {
+      "id": "JttXgTlQAGE",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Ganya MCHP"
+      }
+    },
+    {
+      "id": "HDOnfLXKkYs",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Hamdalai MCHP"
+      }
+    },
+    {
+      "id": "oolcy5HBlMy",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Hamilton MCHP"
+      }
+    },
+    {
+      "id": "DSBXsRQSXUW",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Handicap Clinic"
+      }
+    },
+    {
+      "id": "g10jm7jPdzf",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Hangha CHC"
+      }
+    },
+    {
+      "id": "VrDA0Hn4Xc6",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Harvest Time MCHP"
+      }
+    },
+    {
+      "id": "zQpYVEyAM2t",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Hastings Health Centre"
+      }
+    },
+    {
+      "id": "XEyIRFd9pct",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Imperi"
+      }
+    },
+    {
+      "id": "wjFsUXI1MlO",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Iscon CHP"
+      }
+    },
+    {
+      "id": "daJPPxtIrQn",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Jaiama Bongor"
+      }
+    },
+    {
+      "id": "W7ekX3gi0ut",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Jaiama Sewafe CHC"
+      }
+    },
+    {
+      "id": "qzm5ww3U0vz",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Jangalor MCHP"
+      }
+    },
+    {
+      "id": "t7bcrWLjL1m",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Jao MCHP"
+      }
+    },
+    {
+      "id": "KSdZwrU7Hh6",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Jawi"
+      }
+    },
+    {
+      "id": "Umh4HKqqFp6",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Jembe CHC"
+      }
+    },
+    {
+      "id": "EQUwHqZOb5L",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Kabaima MCHP"
+      }
+    },
+    {
+      "id": "Xk2fvz4aTBU",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Kabati CHP"
+      }
+    },
+    {
+      "id": "TWMVxJANJeU",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Kabba Ferry MCHP"
+      }
+    },
+    {
+      "id": "CbIWQQoWcLc",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Kabombeh MCHP"
+      }
+    },
+    {
+      "id": "wfGRNqXqf92",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Kabonka MCHP"
+      }
+    },
+    {
+      "id": "BmYyh9bZ0sr",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Kafe Simira"
+      }
+    },
+    {
+      "id": "yg7uxUol97F",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Laiya CHP"
+      }
+    },
+    {
+      "id": "K0d08d3sUOv",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Lakka Hospital"
+      }
+    },
+    {
+      "id": "NRPCjDljVtu",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Lakka/Ogoo Farm CHC"
+      }
+    },
+    {
+      "id": "SFQblJrFblm",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Laleihun CHP"
+      }
+    },
+    {
+      "id": "N3tpEjZcPm9",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Laleihun Kovoma CHC"
+      }
+    },
+    {
+      "id": "xEip3dtU8bp",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Lango Town MCHP"
+      }
+    },
+    {
+      "id": "c9wCIfbcyVo",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "M I Room (Military)"
+      }
+    },
+    {
+      "id": "Pae8DR7VmcL",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "MCH (Kakua) Static"
+      }
+    },
+    {
+      "id": "kpDoH80fwdX",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "MCH Static"
+      }
+    },
+    {
+      "id": "foPGXhwhlqp",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "MCH Static Pujehun"
+      }
+    },
+    {
+      "id": "w9XjBMJYL9R",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "MCH Static/U5"
+      }
+    },
+    {
+      "id": "voQXVNftP4W",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Maami CHP"
+      }
+    },
+    {
+      "id": "KQFAul3T9xz",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Nafaya MCHP"
+      }
+    },
+    {
+      "id": "nGb94wPdcqx",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Nagbena CHP"
+      }
+    },
+    {
+      "id": "bPHn9IgjKLC",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Nasarah Clinic"
+      }
+    },
+    {
+      "id": "ZsjXrmZS59z",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Ndegbome MCHP"
+      }
+    },
+    {
+      "id": "aBfyTU5Wgds",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Nduvuibu MCHP"
+      }
+    },
+    {
+      "id": "UOJlcpPnBat",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Needy CHC"
+      }
+    },
+    {
+      "id": "tHUYjt9cU6h",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Ola During Clinic"
+      }
+    },
+    {
+      "id": "LqH7ZGU9KAx",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "PCM Hospital"
+      }
+    },
+    {
+      "id": "g7BLyiBb0ET",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "PMO Clinetown"
+      }
+    },
+    {
+      "id": "L8iA6eLwKNb",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Paki Masabong"
+      }
+    },
+    {
+      "id": "PEZNsGbZaVJ",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Panguma Mission Hosp."
+      }
+    },
+    {
+      "id": "zLiMZ1WrxdG",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Panlap MCHP"
+      }
+    },
+    {
+      "id": "tSBcgrTDdB8",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Paramedical CHC"
+      }
+    },
+    {
+      "id": "xXYv82KlBUh",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Quarry MCHP"
+      }
+    },
+    {
+      "id": "VZ6Cocesljy",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Quidadu MCHP"
+      }
+    },
+    {
+      "id": "is3w3HROKVc",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Rapha Clinic"
+      }
+    },
+    {
+      "id": "wNYYRm2c9EK",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Red Cross Clinic"
+      }
+    },
+    {
+      "id": "oRncQGhLYNE",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Regent (RWA) CHC"
+      }
+    },
+    {
+      "id": "gy8rmvYT4cj",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Ribbi"
+      }
+    },
+    {
+      "id": "u6ZGNI8yUmt",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Rina Clinic"
+      }
+    },
+    {
+      "id": "ym42ZOlfZ1P",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Robaka MCHP"
+      }
+    },
+    {
+      "id": "JNJIPX9DfaW",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "S.L.R.C.S Clinic"
+      }
+    },
+    {
+      "id": "nCh5dBoJVNw",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "SL Red Cross (BMC) Clinic"
+      }
+    },
+    {
+      "id": "BLVKubgVxkF",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "SL Red Cross (Gbense) Clinic"
+      }
+    },
+    {
+      "id": "FGbXmz7gTTl",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "SLC. RHC Port Loko"
+      }
+    },
+    {
+      "id": "gmen7SXL9CU",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "SLIMS Clinic"
+      }
+    },
+    {
+      "id": "T2Cn45nBY0u",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "SLRC (Mattru) Clinic"
+      }
+    },
+    {
+      "id": "Zbp8TbiMKVc",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Tabe MCHP"
+      }
+    },
+    {
+      "id": "O63vIA5MVn6",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Tagrin CHC"
+      }
+    },
+    {
+      "id": "e2WgqiasKnD",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Taiama (Kori) CHC"
+      }
+    },
+    {
+      "id": "PrJQHI6q7w2",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Tainkatopa Makama Safrokoh "
+      }
+    },
+    {
+      "id": "qIpBLa1SCZt",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Talia (Nongowa) CHC"
+      }
+    },
+    {
+      "id": "s5aXfzOL456",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Talia CHC"
+      }
+    },
+    {
+      "id": "PdGktj8bAML",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "UBC Under 5"
+      }
+    },
+    {
+      "id": "gGv9ATEs68L",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "UFC Bonthe"
+      }
+    },
+    {
+      "id": "w9FJ9oAdFys",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "UFC Magburaka"
+      }
+    },
+    {
+      "id": "JCXEtUDYyp9",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "UFC Nixon Hospital"
+      }
+    },
+    {
+      "id": "XQudzejlhJZ",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "UFC Nongowa"
+      }
+    },
+    {
+      "id": "SHLY5rkOFTQ",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "UFC Port Loko"
+      }
+    },
+    {
+      "id": "up9gjdODKXE",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Vaahun MCHP"
+      }
+    },
+    {
+      "id": "qAFXoNjlZCB",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Vaama  (kpanga krim) MCHP"
+      }
+    },
+    {
+      "id": "GjJjES51GvK",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Vaama MCHP"
+      }
+    },
+    {
+      "id": "npWGUj37qDe",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Valunia"
+      }
+    },
+    {
+      "id": "SoXpnYO84eZ",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Venima CHP"
+      }
+    },
+    {
+      "id": "dyn5pihalrJ",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Victoria MCHP"
+      }
+    },
+    {
+      "id": "zCSWBz2pyMd",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Wai MCHP"
+      }
+    },
+    {
+      "id": "DlLBIHdpaTy",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Waiima (Kori) MCHP"
+      }
+    },
+    {
+      "id": "YPSCWmJ3TyN",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Waiima MCHP"
+      }
+    },
+    {
+      "id": "m0PiiU5BteW",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Walia MCHP"
+      }
+    },
+    {
+      "id": "tZxqVn3xNrA",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Wallehun MCHP"
+      }
+    },
+    {
+      "id": "X7dWcGerQIm",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Wandor"
+      }
+    },
+    {
+      "id": "pk7bUK5c1Uf",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Ya Kpukumu Krim"
+      }
+    },
+    {
+      "id": "XbyObqerCya",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Yabaima CHP"
+      }
+    },
+    {
+      "id": "AnXoUM1tfNT",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Yakaji MCHP"
+      }
+    },
+    {
+      "id": "sgcHQEaB40Y",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Yalieboya CHP"
+      }
+    },
+    {
+      "id": "nX05QLraDhO",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Yamandu CHC"
+      }
+    },
+    {
+      "id": "QDoO5r6Sae7",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Yambama MCHP"
+      }
+    },
+    {
+      "id": "BNFrspDBKel",
+      "type": "orgUnit",
+      "attributes": {
+        "displayName": "Zimmi CHC"
+      }
+    }
+  ]
+}

--- a/mock-server/data/simulation-pending-4.json
+++ b/mock-server/data/simulation-pending-4.json
@@ -1,0 +1,20 @@
+{
+    "data": {
+        "id": "4",
+        "type": "invoicingJob",
+        "attributes": {
+            "orgUnit": "AOsKyLAjVWH",
+            "dhis2Period": "2018Q3",
+            "user": null,
+            "createdAt": "2019-11-21T08:51:41.010Z",
+            "processedAt": "",
+            "erroredAt": null,
+            "durationMs": null
+            "status": "enqueued",
+            "lastError": null,
+            "sidekiqJobRef": null,
+            "isAlive": true,
+            "resultUrl": null
+        }
+    }
+}

--- a/mock-server/data/simulations.json
+++ b/mock-server/data/simulations.json
@@ -53,6 +53,24 @@
         "isAlive": false,
         "resultUrl": null
       }
+    },
+    {
+      "id": "4",
+      "type": "invoicingJob",
+      "attributes": {
+        "orgUnit": "AOsKyLAjVWH",
+        "dhis2Period": "2018Q3",
+        "user": null,
+        "createdAt": "2019-11-21T08:51:41.010Z",
+        "processedAt": "",
+        "erroredAt": null,
+        "durationMs": null
+        "status": "enqueued",
+        "lastError": null,
+        "sidekiqJobRef": null,
+        "isAlive": true,
+        "resultUrl": null
+      }
     }
   ]
 }


### PR DESCRIPTION
This brings in the `/api/org_units` endpoint which can be used to autocomplete org units based on name or to fetch the name of an org unit id.

`api/org_units?term=term` will return all `org_units` that have a (case insensitive) diplayName which includes 'term' (e.g. "my-term-and-me", "term-and-so-on", "Terminator")

`api/org_units?id=Aoxbk` will return all `org_units` with that dhis-id. (it's an array with always one result normally)

`api/org_units` will display all known org units that Hesabu knows about (currently it's unpaginated)

I've also added an example of a simualation that is not yet processed.

