### PR TITLE
feat: Force auto reload for processed sims

### DIFF
--- a/src/components/Simulation/index.js
+++ b/src/components/Simulation/index.js
@@ -1,4 +1,10 @@
-import { Dialog, Typography, Slide } from "@material-ui/core";
+import {
+  Dialog,
+  Typography,
+  Slide,
+  FormControlLabel,
+  Switch,
+} from "@material-ui/core";
 import { ExpandableBottomSheet } from "@blsq/manager-ui";
 import React, { useState, useEffect, Fragment } from "react";
 import PropTypes from "prop-types";
@@ -24,9 +30,17 @@ export const Simulation = props => {
   const history = useHistory();
   const [sideSheetOpen, setSideSheetOpen] = useState(false);
   const [bottomSheetOpen, setBottomSheetOpen] = useState(false);
-  const { selectedCell } = props;
 
-  const { errorMessage, t, open, simulation, loading } = props;
+  const {
+    errorMessage,
+    t,
+    open,
+    simulation,
+    loading,
+    selectedCell,
+    polling,
+  } = props;
+
   const handleToggleSideSheet = () => {
     if (sideSheetOpen) {
       if (selectedCell) {
@@ -71,6 +85,16 @@ export const Simulation = props => {
         >
           {title} {(simulation || {}).status}
         </Typography>
+        <FormControlLabel
+          control={
+            <Switch
+              checked={polling}
+              onChange={props.onPollingChange}
+              value={"polling"}
+            />
+          }
+          label={t("buttons.autoreload")}
+        />
         <FiltersToggleBtn
           variant="filters"
           className={classes.filtersBtn}

--- a/src/containers/SimulationContainer/index.js
+++ b/src/containers/SimulationContainer/index.js
@@ -12,6 +12,7 @@ class SimulationContainer extends Component {
     super(props);
     this.state = {
       loading: true,
+      forcePolling: false,
       errorMessage: undefined,
       simulation: undefined,
       polling: false,
@@ -23,7 +24,14 @@ class SimulationContainer extends Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
+    if (this.state.forcePolling && !this.state.loading) {
+      setTimeout(() => {
+        this.fetchSimulation();
+      }, 2000);
+    }
+
     if (
+      !this.state.forcePolling &&
       this.state.polling &&
       !this.state.loading &&
       this.state.loading !== prevState.loading
@@ -39,6 +47,8 @@ class SimulationContainer extends Component {
   }
 
   fetchSimulation() {
+    console.log("hedd");
+
     this.setState({ loading: true });
     externalApi()
       .errorType("json")
@@ -62,8 +72,12 @@ class SimulationContainer extends Component {
       });
   }
 
+  handlePollingChange = () => {
+    this.setState({ forcePolling: !this.state.forcePolling });
+  };
+
   render() {
-    const { loading, simulation, errorMessage } = this.state;
+    const { loading, simulation, errorMessage, forcePolling } = this.state;
     const valuesFromParams = queryString.parse(this.props.location.search);
 
     return (
@@ -72,6 +86,8 @@ class SimulationContainer extends Component {
         loading={loading}
         simulation={simulation}
         valuesFromParams={valuesFromParams}
+        polling={this.state.polling || forcePolling}
+        onPollingChange={this.handlePollingChange}
         open={true}
       />
     );

--- a/src/containers/SimulationContainer/index.js
+++ b/src/containers/SimulationContainer/index.js
@@ -47,8 +47,6 @@ class SimulationContainer extends Component {
   }
 
   fetchSimulation() {
-    console.log("hedd");
-
     this.setState({ loading: true });
     externalApi()
       .errorType("json")

--- a/src/lib/translations/en.js
+++ b/src/lib/translations/en.js
@@ -6,6 +6,7 @@ export default {
         orgUnits: "Choose an org unit",
       },
       buttons: {
+        autoreload: "Auto reload",
         search: "Search",
         back: "Back",
         save: "Save",

--- a/src/lib/translations/fr.js
+++ b/src/lib/translations/fr.js
@@ -5,6 +5,7 @@ export default {
         orgUnits: "Choisissez une unité d’organisation",
       },
       buttons: {
+        autoreload: "Rafraichissement auto",
         search: "Rechercher",
         back: "Retour",
         save: "Sauver",


### PR DESCRIPTION
If you want to pick up the changes from your sets, you need to keep asking the controller if the sim needs to be regen. Hence you need a way to force auto reload even if the sim is already processed.
![Capture d’écran 2020-01-09 à 13 50 09](https://user-images.githubusercontent.com/39081/72069203-f4412b80-32e6-11ea-8d75-15206f9b15ad.png)
