### PR TITLE
feat: Add warning when no sim blocks for current org unit

### DIFF
--- a/src/components/Simulation/SimulationBlocks.js
+++ b/src/components/Simulation/SimulationBlocks.js
@@ -2,8 +2,17 @@ import React, { useEffect, useState } from "react";
 import groupBy from "lodash/groupBy";
 import PropTypes from "prop-types";
 import wretch from "wretch";
-import { CircularProgress } from "@material-ui/core";
+import { CircularProgress, Typography, makeStyles } from "@material-ui/core";
+import { InfoBox } from "@blsq/manager-ui";
+import { useTranslation } from "react-i18next";
 import SimulationBlock from "./SimulationBlock";
+import EmptySection from "../EmptySection";
+
+const useStyles = makeStyles(theme => ({
+  spaced: {
+    marginTop: theme.spacing(4),
+  },
+}));
 
 const SimulationBlocks = props => {
   const [data, setData] = useState(undefined);
@@ -11,7 +20,8 @@ const SimulationBlocks = props => {
   const [error, setError] = useState(null);
   const [loading, setLoading] = useState(false);
   const setsByCode = groupBy((data || {}).invoices, "code");
-
+  const classes = useStyles();
+  const { t } = useTranslation();
   useEffect(() => {
     setLoading(true);
     wretch()
@@ -53,6 +63,18 @@ const SimulationBlocks = props => {
   const filteredSets = displayedSetCodes.length
     ? sets.filter(setKey => displayedSetCodes.includes(setKey))
     : sets;
+
+  if (!filteredSets.length) {
+    return (
+      <EmptySection>
+        <Typography variant="h6">{t("simulation.ohNo")}</Typography>
+        <InfoBox
+          text={t("simulation.noSimulationForOrgUnit")}
+          className={classes.spaced}
+        />
+      </EmptySection>
+    );
+  }
   return filteredSets.map(key => (
     <SimulationBlock key={key} title={key} periodViews={setsByCode[key]} />
   ));

--- a/src/lib/translations/en.js
+++ b/src/lib/translations/en.js
@@ -65,6 +65,9 @@ export default {
         sidesheet: {
           title: "Filters",
         },
+        ohNo: "Oh no",
+        noSimulationForOrgUnit:
+          "It looks like there is no set associated with this organization unit.",
       },
       simulationForm: {
         projectVersion: {

--- a/src/lib/translations/fr.js
+++ b/src/lib/translations/fr.js
@@ -65,6 +65,9 @@ export default {
         sidesheet: {
           title: "Filtres",
         },
+        ohNo: "Oh no",
+        noSimulationForOrgUnit:
+          "Il semble qu’il n’y ai aucun set associé à cette unité d’organisation. Choisissez une autre unité d’organisation ou ajouter celle-ci dans les groupes d’unité d’organisations que vous utilisez pour vos sets.",
       },
       simulationForm: {
         projectVersion: {


### PR DESCRIPTION
If current org unit is not included in the sets org units it shows a warning
![Capture d’écran 2020-01-09 à 14 44 23](https://user-images.githubusercontent.com/39081/72072560-8993ee00-32ee-11ea-808c-76b9feda1dd5.png)
