### PR TITLE
Expose a sets endpoints

### DIFF
--- a/mock-server/README.md
+++ b/mock-server/README.md
@@ -1,6 +1,8 @@
 `/api/project` => Returns the information on the current project
 
-`/api/simulations`   => Returns all ran simulations
+`/api/simulations` => Returns all sets available in the project
+
+`/api/simulations` => Returns all ran simulations
 
 You can access using simulation id (which is unique):
 

--- a/mock-server/README.md
+++ b/mock-server/README.md
@@ -1,6 +1,6 @@
 `/api/project` => Returns the information on the current project
 
-`/api/simulations` => Returns all sets available in the project
+`/api/sets` => Returns all sets available in the project
 
 `/api/simulations` => Returns all ran simulations
 

--- a/mock-server/app.rb
+++ b/mock-server/app.rb
@@ -26,6 +26,10 @@ get '/' do
   'Hello world!'
 end
 
+get '/api/sets' do
+  File.read("data/sets.json")
+end
+
 get '/api/simulations' do
   File.read("data/simulations.json")
 end

--- a/mock-server/data/sets.json
+++ b/mock-server/data/sets.json
@@ -1,0 +1,409 @@
+{
+  "data": [
+    {
+      "id": "4",
+      "type": "set",
+      "attributes": {
+        "name": "Performance Adm",
+        "description": null,
+        "frequency": "quarterly",
+        "kind": "single",
+        "include_main_orgunit": false,
+        "loop_over_combo_ext_id": null,
+        "data_element_group_ext_ref": "data_element_group_ext_ref"
+      },
+      "relationships": {
+        "org_unit_groups": {
+          "data": [
+            {
+              "id": "w0gFTTmsUcF",
+              "type": "org_unit_group"
+            }
+          ]
+        },
+        "org_unit_group_sets": {
+          "data": []
+        },
+        "inputs": {
+          "data": [
+            {
+              "id": "1",
+              "type": "input"
+            },
+            {
+              "id": "4",
+              "type": "input"
+            },
+            {
+              "id": "6",
+              "type": "input"
+            }
+          ]
+        },
+        "topic_formulas": {
+          "data": [
+            {
+              "id": "21",
+              "type": "topic_formula"
+            },
+            {
+              "id": "22",
+              "type": "topic_formula"
+            },
+            {
+              "id": "23",
+              "type": "topic_formula"
+            }
+          ]
+        },
+        "topics": {
+          "data": [
+            {
+              "id": "2",
+              "type": "topic"
+            },
+            {
+              "id": "1",
+              "type": "topic"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "2",
+      "type": "set",
+      "attributes": {
+        "name": "Quality",
+        "description": null,
+        "frequency": "quarterly",
+        "kind": "single",
+        "include_main_orgunit": false,
+        "loop_over_combo_ext_id": null,
+        "data_element_group_ext_ref": "data_element_group_ext_ref"
+      },
+      "relationships": {
+        "org_unit_groups": {
+          "data": [
+            {
+              "id": "RXL3lPSK8oG",
+              "type": "org_unit_group"
+            },
+            {
+              "id": "tDZVQ1WtwpA",
+              "type": "org_unit_group"
+            }
+          ]
+        },
+        "org_unit_group_sets": {
+          "data": []
+        },
+        "inputs": {
+          "data": [
+            {
+              "id": "1",
+              "type": "input"
+            },
+            {
+              "id": "2",
+              "type": "input"
+            },
+            {
+              "id": "4",
+              "type": "input"
+            }
+          ]
+        },
+        "topic_formulas": {
+          "data": [
+            {
+              "id": "8",
+              "type": "topic_formula"
+            },
+            {
+              "id": "9",
+              "type": "topic_formula"
+            },
+            {
+              "id": "10",
+              "type": "topic_formula"
+            }
+          ]
+        },
+        "topics": {
+          "data": [
+            {
+              "id": "2",
+              "type": "topic"
+            },
+            {
+              "id": "1",
+              "type": "topic"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "3",
+      "type": "set",
+      "attributes": {
+        "name": "Quantity PCA",
+        "description": null,
+        "frequency": "monthly",
+        "kind": "single",
+        "include_main_orgunit": false,
+        "loop_over_combo_ext_id": null,
+        "data_element_group_ext_ref": "data_element_group_ext_ref"
+      },
+      "relationships": {
+        "org_unit_groups": {
+          "data": [
+            {
+              "id": "tDZVQ1WtwpA",
+              "type": "org_unit_group"
+            }
+          ]
+        },
+        "org_unit_group_sets": {
+          "data": []
+        },
+        "inputs": {
+          "data": [
+            {
+              "id": "1",
+              "type": "input"
+            },
+            {
+              "id": "2",
+              "type": "input"
+            },
+            {
+              "id": "5",
+              "type": "input"
+            }
+          ]
+        },
+        "topic_formulas": {
+          "data": [
+            {
+              "id": "17",
+              "type": "topic_formula"
+            },
+            {
+              "id": "18",
+              "type": "topic_formula"
+            },
+            {
+              "id": "19",
+              "type": "topic_formula"
+            }
+          ]
+        },
+        "topics": {
+          "data": [
+            {
+              "id": "2",
+              "type": "topic"
+            },
+            {
+              "id": "1",
+              "type": "topic"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "1",
+      "type": "set",
+      "attributes": {
+        "name": "Quantity PMA",
+        "description": null,
+        "frequency": "monthly",
+        "kind": "single",
+        "include_main_orgunit": false,
+        "loop_over_combo_ext_id": null,
+        "data_element_group_ext_ref": "data_element_group_ext_ref"
+      },
+      "relationships": {
+        "org_unit_groups": {
+          "data": [
+            {
+              "id": "RXL3lPSK8oG",
+              "type": "org_unit_group"
+            }
+          ]
+        },
+        "org_unit_group_sets": {
+          "data": []
+        },
+        "inputs": {
+          "data": [
+            {
+              "id": "1",
+              "type": "input"
+            },
+            {
+              "id": "2",
+              "type": "input"
+            },
+            {
+              "id": "5",
+              "type": "input"
+            }
+          ]
+        },
+        "topic_formulas": {
+          "data": [
+            {
+              "id": "4",
+              "type": "topic_formula"
+            },
+            {
+              "id": "5",
+              "type": "topic_formula"
+            },
+            {
+              "id": "6",
+              "type": "topic_formula"
+            }
+          ]
+        },
+        "topics": {
+          "data": [
+            {
+              "id": "2",
+              "type": "topic"
+            },
+            {
+              "id": "1",
+              "type": "topic"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "included": [
+    {
+      "id": "1",
+      "type": "input",
+      "attributes": {
+        "name": "Claimed",
+        "short_name": null
+      }
+    },
+    {
+      "id": "4",
+      "type": "input",
+      "attributes": {
+        "name": "Max. Score",
+        "short_name": null
+      }
+    },
+    {
+      "id": "6",
+      "type": "input",
+      "attributes": {
+        "name": "Budget",
+        "short_name": null
+      }
+    },
+    {
+      "id": "w0gFTTmsUcF",
+      "type": "orgUnitGroup",
+      "attributes": {
+        "value": "Administrative",
+        "id": "w0gFTTmsUcF",
+        "name": "Administrative"
+      }
+    },
+    {
+      "id": "2",
+      "type": "topic",
+      "attributes": {
+        "code": "clients_sous_traitement_arv_suivi_pendant_les_6_premiers_mois",
+        "name": "Clients sous traitement ARV suivi pendant les 6 premiers mois",
+        "short_name": null,
+        "created_at": "2020-01-10T10:17:39.935Z",
+        "updated_at": "2020-01-10T10:17:39.935Z",
+        "stable_id": "56951288-4759-4ac5-9bd3-20d92a5e3ccb"
+      },
+      "relationships": {
+        "inputs": {
+          "data": [
+            {
+              "id": "3",
+              "type": "input"
+            },
+            {
+              "id": "4",
+              "type": "input"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "1",
+      "type": "topic",
+      "attributes": {
+        "code": "vaccination",
+        "name": "Vaccination",
+        "short_name": null,
+        "created_at": "2020-01-10T10:17:39.922Z",
+        "updated_at": "2020-01-10T10:17:39.922Z",
+        "stable_id": "075a9440-a10a-4528-8df4-18e876abc7f8"
+      },
+      "relationships": {
+        "inputs": {
+          "data": [
+            {
+              "id": "1",
+              "type": "input"
+            },
+            {
+              "id": "2",
+              "type": "input"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "2",
+      "type": "input",
+      "attributes": {
+        "name": "Verified",
+        "short_name": null
+      }
+    },
+    {
+      "id": "RXL3lPSK8oG",
+      "type": "orgUnitGroup",
+      "attributes": {
+        "value": "Clinic",
+        "id": "RXL3lPSK8oG",
+        "name": "Clinic"
+      }
+    },
+    {
+      "id": "tDZVQ1WtwpA",
+      "type": "orgUnitGroup",
+      "attributes": {
+        "value": "Hospital",
+        "id": "tDZVQ1WtwpA",
+        "name": "Hospital"
+      }
+    },
+    {
+      "id": "5",
+      "type": "input",
+      "attributes": {
+        "name": "Tarif",
+        "short_name": null
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This will return all info about a set that we currently have (if there
is anything missing it will be added but the structure seems to be
this)

It's a JSON-API compound document, so you have your normal:

```
data: [
  { id: "1",
    type: "set"
    attributes: {
      // List of attrubites on the set
    }
  },
  "relationships": {
    // Currently listing: org_unit_groups, org_unit_group_sets,
    //  inputs, topics and topic_formulas
  }
]
```

Now what makes it a compound document, is that the info for the relationships is included, next to the data leaf is an included leaf which contains all the data needed to render the relationships:

```
included: [
  {
      "id": "1",
      "type": "input",
      "attributes": {
        "name": "Claimed",
        "short_name": null
      }
    },
]
```

So if you need to find the info about input with id 1, you need to look in the `included` array and do a search for `id=1` and `type=input`, and then you can retrieve the attributes without having
to make an additional call.

If you use: https://github.com/itsfadnis/jsonapi-serializer#deserialization, this will do that for free for you.

I tested this with:

``` js
      const JSONAPIDeserializer = require('jsonapi-serializer').Deserializer;
      const sets = require("./sets.json")
      new JSONAPIDeserializer().deserialize(sets, (e, u) => console.log(u));
      // THis will show the entire output, but will show [object object] for
      // the relationships
      new JSONAPIDeserializer().deserialize(sets, (e, u) => console.log(u[0].inputs));

      [ { name: 'Claimed', 'short-name': null, id: '1' },
        { name: 'Max. Score', 'short-name': null, id: '4' },
        { name: 'Budget', 'short-name': null, id: '6' } ]
```

So it already does the lookups, and you don't need to do it anymore.