### PR TITLE
Expose show pages for sets and set groups

### DIFF
--- a/mock-server/app.rb
+++ b/mock-server/app.rb
@@ -30,8 +30,18 @@ get '/api/sets' do
   File.read("data/sets.json")
 end
 
+get '/api/sets/:identifier' do |identifier|
+  _id = identifier
+  File.read("data/set.json")
+end
+
 get '/api/set_groups' do
   File.read("data/set_groups.json")
+end
+
+get '/api/set_groups/:identifier' do |identifier|
+  _id = identifier
+  File.read("data/set_group.json")
 end
 
 get '/api/simulations' do

--- a/mock-server/data/set.json
+++ b/mock-server/data/set.json
@@ -1,0 +1,159 @@
+{
+  "data": {
+    "id": "13",
+    "type": "set",
+    "attributes": {
+      "name": "Quantity PMA",
+      "description": null,
+      "frequency": "monthly",
+      "kind": "single",
+      "includeMainOrgunit": false,
+      "loopOverComboExtId": null,
+      "dataElementGroupExtRef": "data_element_group_ext_ref"
+    },
+    "relationships": {
+      "orgUnitGroups": {
+        "data": [
+          {
+            "id": "RXL3lPSK8oG",
+            "type": "orgUnitGroup"
+          }
+        ]
+      },
+      "orgUnitGroupSets": {
+        "data": []
+      },
+      "inputs": {
+        "data": [
+          {
+            "id": "28",
+            "type": "input"
+          },
+          {
+            "id": "29",
+            "type": "input"
+          },
+          {
+            "id": "32",
+            "type": "input"
+          }
+        ]
+      },
+      "topicFormulas": {
+        "data": [
+          {
+            "id": "85",
+            "type": "topicFormula"
+          },
+          {
+            "id": "86",
+            "type": "topicFormula"
+          },
+          {
+            "id": "87",
+            "type": "topicFormula"
+          }
+        ]
+      },
+      "topics": {
+        "data": [
+          {
+            "id": "8",
+            "type": "topic"
+          },
+          {
+            "id": "7",
+            "type": "topic"
+          }
+        ]
+      }
+    }
+  },
+  "included": [
+    {
+      "id": "28",
+      "type": "input",
+      "attributes": {
+        "name": "Claimed",
+        "shortName": null
+      }
+    },
+    {
+      "id": "29",
+      "type": "input",
+      "attributes": {
+        "name": "Verified",
+        "shortName": null
+      }
+    },
+    {
+      "id": "32",
+      "type": "input",
+      "attributes": {
+        "name": "Tarif",
+        "shortName": null
+      }
+    },
+    {
+      "id": "RXL3lPSK8oG",
+      "type": "orgUnitGroup",
+      "attributes": {
+        "value": "Clinic",
+        "id": "RXL3lPSK8oG",
+        "name": "Clinic"
+      }
+    },
+    {
+      "id": "8",
+      "type": "topic",
+      "attributes": {
+        "code": "clients_sous_traitement_arv_suivi_pendant_les_6_premiers_mois",
+        "name": "Clients sous traitement ARV suivi pendant les 6 premiers mois",
+        "shortName": null,
+        "createdAt": "2020-01-13T11:21:56.482Z",
+        "updatedAt": "2020-01-13T11:21:56.482Z",
+        "stableId": "6ee73dcf-602e-4da2-8d9d-0bfa0e90dd1b"
+      },
+      "relationships": {
+        "inputs": {
+          "data": [
+            {
+              "id": "15",
+              "type": "input"
+            },
+            {
+              "id": "16",
+              "type": "input"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "7",
+      "type": "topic",
+      "attributes": {
+        "code": "vaccination",
+        "name": "Vaccination",
+        "shortName": null,
+        "createdAt": "2020-01-13T11:21:56.475Z",
+        "updatedAt": "2020-01-13T11:21:56.475Z",
+        "stableId": "e69703ee-01fd-44ed-b469-a0062e37d5dc"
+      },
+      "relationships": {
+        "inputs": {
+          "data": [
+            {
+              "id": "13",
+              "type": "input"
+            },
+            {
+              "id": "14",
+              "type": "input"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/mock-server/data/set_group.json
+++ b/mock-server/data/set_group.json
@@ -1,0 +1,76 @@
+{
+  "data": {
+    "id": "3",
+    "type": "setGroup",
+    "attributes": {
+      "name": "Payment rule pma",
+      "frequency": "quarterly",
+      "stableId": "9a41700f-d8e9-43b3-a18a-bdb7f2ca9abc"
+    },
+    "relationships": {
+      "formulas": {
+        "data": [
+          {
+            "id": "28",
+            "type": "formula"
+          },
+          {
+            "id": "29",
+            "type": "formula"
+          },
+          {
+            "id": "30",
+            "type": "formula"
+          }
+        ]
+      }
+    }
+  },
+  "included": [
+    {
+      "id": "28",
+      "type": "formula",
+      "attributes": {
+        "id": 28,
+        "code": "quality_bonus_percentage_value",
+        "description": "Quality bonus percentage",
+        "exportableFormulaCode": null,
+        "expression": "IF(quality_technical_score_value > 50, (0.35 * quality_technical_score_value) + (0.30 * 10.0), 0.0)",
+        "frequency": null,
+        "shortName": null,
+        "createdAt": "2020-01-13T11:21:53.402Z",
+        "updatedAt": "2020-01-13T11:21:53.402Z"
+      }
+    },
+    {
+      "id": "29",
+      "type": "formula",
+      "attributes": {
+        "id": 29,
+        "code": "quality_bonus_value",
+        "description": "Bonus qualité",
+        "exportableFormulaCode": null,
+        "expression": "quantity_total_pma * quality_bonus_percentage_value",
+        "frequency": null,
+        "shortName": null,
+        "createdAt": "2020-01-13T11:21:53.403Z",
+        "updatedAt": "2020-01-13T11:21:53.403Z"
+      }
+    },
+    {
+      "id": "30",
+      "type": "formula",
+      "attributes": {
+        "id": 30,
+        "code": "quarterly_payment",
+        "description": "Quarterly Payment",
+        "exportableFormulaCode": null,
+        "expression": "quantity_total_pma + quality_bonus_value",
+        "frequency": null,
+        "shortName": null,
+        "createdAt": "2020-01-13T11:21:53.404Z",
+        "updatedAt": "2020-01-13T11:21:53.404Z"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This will limit the request to a single resource, instead of returning all the resources.

`/set/:identifier`
`/set_group/:identifier`

(Currently they always return the same data, regardless of which identifier we're passing, this can be expanded with 'smarter' responses if needed)