### PR TITLE
fix: Remove doubled occurrence of periods in simulation

### DIFF
--- a/src/components/Simulation/SimulationBlocks.js
+++ b/src/components/Simulation/SimulationBlocks.js
@@ -20,7 +20,16 @@ const SimulationBlocks = props => {
   // #TODO add some loading states
   const [error, setError] = useState(null);
   const [loading, setLoading] = useState(false);
-  const setsByCode = groupBy((data || {}).invoices, "code");
+  const invoices = (data || {}).invoices || [];
+
+  // Placeholder to only display the selected org unit, in the future
+  // the backend should do this filtering for us.
+  const displayedOrgUnit = props.searchQuery.orgUnit || "";
+  const invoicesForOrgUnit = invoices.filter(
+    ({ orgunit_ext_id }) => orgunit_ext_id == displayedOrgUnit,
+  );
+
+  const setsByCode = groupBy(invoicesForOrgUnit, "code");
 
   const classes = useStyles();
   const { t } = useTranslation();

--- a/src/components/Simulation/SimulationBlocks.js
+++ b/src/components/Simulation/SimulationBlocks.js
@@ -20,16 +20,18 @@ const SimulationBlocks = props => {
   // #TODO add some loading states
   const [error, setError] = useState(null);
   const [loading, setLoading] = useState(false);
-  const invoices = (data || {}).invoices || [];
+  const sets = (data || {}).invoices || [];
 
   // Placeholder to only display the selected org unit, in the future
   // the backend should do this filtering for us.
   const displayedOrgUnit = props.searchQuery.orgUnit || "";
-  const invoicesForOrgUnit = invoices.filter(
-    ({ orgunit_ext_id }) => orgunit_ext_id == displayedOrgUnit,
-  );
+  const setsForOrgUnit = useMemo(() => {
+    return sets.filter(
+      ({ orgunit_ext_id }) => orgunit_ext_id === displayedOrgUnit,
+    );
+  }, [sets, displayedOrgUnit]);
 
-  const setsByCode = groupBy(invoicesForOrgUnit, "code");
+  const setsByCode = groupBy(setsForOrgUnit, "code");
 
   const classes = useStyles();
   const { t } = useTranslation();
@@ -65,16 +67,16 @@ const SimulationBlocks = props => {
     .split(",")
     .filter(i => i);
 
-  const sets = Object.keys(setsByCode);
+  const setCodes = Object.keys(setsByCode);
 
   const filteredSets = useMemo(() => {
-    if (!displayedSetCodes.length) return sets;
-    return sets.filter(setKey => {
+    if (!displayedSetCodes.length) return setCodes;
+    return setCodes.filter(setKey => {
       return matchSorter(displayedSetCodes, getSetName(setKey), {
         threshold: matchSorter.rankings.CONTAINS,
       }).length;
     });
-  }, [sets, displayedSetCodes]);
+  }, [setCodes, displayedSetCodes]);
 
   if (loading) {
     return <CircularProgress />;


### PR DESCRIPTION
This was triggered because the backend just returns all the org_units
it discovered in the simulation, not just the selected one.

Since fixing this at the backend layer would be a lot of strain on the
Rails server (it would need to pull down the JSON blob from S3, parse
it, select only the correct parts, then push the JSON blob back to the
frontedn), for now we fix it on the front end.

On the plus side, this makes the simulation page faster because it has
less to render.