### PR TITLE
Expose input mappings of set

### DIFF
--- a/mock-server/data/compound_80.json
+++ b/mock-server/data/compound_80.json
@@ -104,6 +104,16 @@
         "shortName": "Total Qualité",
         "createdAt": "2019-04-23T12:02:50.731Z",
         "updatedAt": "2019-05-15T09:44:01.771Z"
+      },
+      "relationships": {
+        "formulaMappings": {
+          "data": [
+            {
+              "id": "4026",
+              "type": "formulaMapping"
+            }
+          ]
+        }
       }
     },
     {
@@ -119,6 +129,16 @@
         "shortName": "total",
         "createdAt": "2019-04-04T11:23:04.430Z",
         "updatedAt": "2019-05-11T17:01:39.625Z"
+      },
+      "relationships": {
+        "formulaMappings": {
+          "data": [
+            {
+              "id": "4021",
+              "type": "formulaMapping"
+            }
+          ]
+        }
       }
     },
     {
@@ -134,6 +154,16 @@
         "shortName": "Qualité Globale",
         "createdAt": "2019-05-11T16:41:29.416Z",
         "updatedAt": "2019-05-15T07:31:54.436Z"
+      },
+      "relationships": {
+        "formulaMappings": {
+          "data": [
+            {
+              "id": "4160",
+              "type": "formulaMapping"
+            }
+          ]
+        }
       }
     },
     {
@@ -149,6 +179,16 @@
         "shortName": "b_total_subsidies",
         "createdAt": "2019-05-15T09:44:01.783Z",
         "updatedAt": "2019-05-15T09:44:01.783Z"
+      },
+      "relationships": {
+        "formulaMappings": {
+          "data": [
+            {
+              "id": "4184",
+              "type": "formulaMapping"
+            }
+          ]
+        }
       }
     }
   ]

--- a/mock-server/data/compound_87.json
+++ b/mock-server/data/compound_87.json
@@ -96,6 +96,16 @@
         "shortName": "total",
         "createdAt": "2019-05-23T08:56:38.810Z",
         "updatedAt": "2019-06-03T08:49:52.643Z"
+      },
+      "relationships": {
+        "formulaMappings": {
+          "data": [
+            {
+              "id": "4347",
+              "type": "formulaMapping"
+            }
+          ]
+        }
       }
     },
     {
@@ -111,6 +121,16 @@
         "shortName": "PTD - Subsides obtenus pour la Section A",
         "createdAt": "2019-05-22T14:10:22.756Z",
         "updatedAt": "2019-05-28T08:39:45.207Z"
+      },
+      "relationships": {
+        "formulaMappings": {
+          "data": [
+            {
+              "id": "4346",
+              "type": "formulaMapping"
+            }
+          ]
+        }
       }
     },
     {
@@ -126,6 +146,16 @@
         "shortName": "PTD - Subsides obtenus pour la Section B",
         "createdAt": "2019-05-29T09:03:50.029Z",
         "updatedAt": "2019-05-29T09:03:50.029Z"
+      },
+      "relationships": {
+        "formulaMappings": {
+          "data": [
+            {
+              "id": "4520",
+              "type": "formulaMapping"
+            }
+          ]
+        }
       }
     },
     {
@@ -141,6 +171,16 @@
         "shortName": "PTD - Subsides obtenus pour la Section C",
         "createdAt": "2019-06-03T08:49:52.650Z",
         "updatedAt": "2019-06-03T08:49:52.650Z"
+      },
+      "relationships": {
+        "formulaMappings": {
+          "data": [
+            {
+              "id": "4521",
+              "type": "formulaMapping"
+            }
+          ]
+        }
       }
     }
   ]

--- a/mock-server/data/compound_92.json
+++ b/mock-server/data/compound_92.json
@@ -116,6 +116,16 @@
         "shortName": "total",
         "createdAt": "2019-06-11T10:03:15.980Z",
         "updatedAt": "2019-06-11T10:03:15.980Z"
+      },
+      "relationships": {
+        "formulaMappings": {
+          "data": [
+            {
+              "id": "4603",
+              "type": "formulaMapping"
+            }
+          ]
+        }
       }
     },
     {
@@ -131,6 +141,16 @@
         "shortName": "PTSD - A Subsides Obtenus",
         "createdAt": "2019-06-11T10:00:55.986Z",
         "updatedAt": "2019-06-18T06:36:06.133Z"
+      },
+      "relationships": {
+        "formulaMappings": {
+          "data": [
+            {
+              "id": "4600",
+              "type": "formulaMapping"
+            }
+          ]
+        }
       }
     },
     {
@@ -146,6 +166,16 @@
         "shortName": "PTSD - B Subsides Obtenus",
         "createdAt": "2019-06-11T09:42:46.569Z",
         "updatedAt": "2019-06-18T06:36:06.145Z"
+      },
+      "relationships": {
+        "formulaMappings": {
+          "data": [
+            {
+              "id": "4601",
+              "type": "formulaMapping"
+            }
+          ]
+        }
       }
     },
     {
@@ -161,6 +191,16 @@
         "shortName": "PTSD - C Subsides Obtenus",
         "createdAt": "2019-06-11T10:02:34.020Z",
         "updatedAt": "2019-06-18T06:36:35.696Z"
+      },
+      "relationships": {
+        "formulaMappings": {
+          "data": [
+            {
+              "id": "4602",
+              "type": "formulaMapping"
+            }
+          ]
+        }
       }
     }
   ]

--- a/mock-server/data/compound_93.json
+++ b/mock-server/data/compound_93.json
@@ -96,6 +96,16 @@
         "shortName": "total",
         "createdAt": "2019-06-14T14:04:06.579Z",
         "updatedAt": "2019-06-18T10:15:47.827Z"
+      },
+      "relationships": {
+        "formulaMappings": {
+          "data": [
+            {
+              "id": "4684",
+              "type": "formulaMapping"
+            }
+          ]
+        }
       }
     },
     {
@@ -111,6 +121,16 @@
         "shortName": "INSPOOL - Subsides obtenus pour la Section C",
         "createdAt": "2019-06-14T14:04:06.571Z",
         "updatedAt": "2019-06-18T10:15:47.839Z"
+      },
+      "relationships": {
+        "formulaMappings": {
+          "data": [
+            {
+              "id": "4683",
+              "type": "formulaMapping"
+            }
+          ]
+        }
       }
     },
     {
@@ -126,6 +146,16 @@
         "shortName": "INSPOOL - Subsides obtenus pour la Section B",
         "createdAt": "2019-06-14T14:04:06.563Z",
         "updatedAt": "2019-06-18T10:15:47.849Z"
+      },
+      "relationships": {
+        "formulaMappings": {
+          "data": [
+            {
+              "id": "4682",
+              "type": "formulaMapping"
+            }
+          ]
+        }
       }
     },
     {
@@ -141,6 +171,16 @@
         "shortName": "INSPOOL - Subsides obtenus pour la Section A",
         "createdAt": "2019-06-14T14:04:06.555Z",
         "updatedAt": "2019-06-18T10:15:47.859Z"
+      },
+      "relationships": {
+        "formulaMappings": {
+          "data": [
+            {
+              "id": "4681",
+              "type": "formulaMapping"
+            }
+          ]
+        }
       }
     }
   ]

--- a/mock-server/data/compound_94.json
+++ b/mock-server/data/compound_94.json
@@ -144,6 +144,16 @@
         "shortName": "total",
         "createdAt": "2019-06-26T05:48:57.525Z",
         "updatedAt": "2019-06-26T15:25:30.472Z"
+      },
+      "relationships": {
+        "formulaMappings": {
+          "data": [
+            {
+              "id": "4695",
+              "type": "formulaMapping"
+            }
+          ]
+        }
       }
     },
     {
@@ -159,6 +169,16 @@
         "shortName": "IPP - Subsides obtenus pour la Section A",
         "createdAt": "2019-06-26T15:25:30.483Z",
         "updatedAt": "2019-06-26T15:25:30.483Z"
+      },
+      "relationships": {
+        "formulaMappings": {
+          "data": [
+            {
+              "id": "4692",
+              "type": "formulaMapping"
+            }
+          ]
+        }
       }
     },
     {
@@ -174,6 +194,16 @@
         "shortName": "IPP - Subsides obtenus pour la Section B",
         "createdAt": "2019-06-26T15:25:30.490Z",
         "updatedAt": "2019-06-26T15:25:30.490Z"
+      },
+      "relationships": {
+        "formulaMappings": {
+          "data": [
+            {
+              "id": "4693",
+              "type": "formulaMapping"
+            }
+          ]
+        }
       }
     },
     {
@@ -189,6 +219,16 @@
         "shortName": "IPP - Subsides obtenus pour la Section C",
         "createdAt": "2019-06-26T15:25:30.497Z",
         "updatedAt": "2019-06-26T15:25:30.497Z"
+      },
+      "relationships": {
+        "formulaMappings": {
+          "data": [
+            {
+              "id": "4694",
+              "type": "formulaMapping"
+            }
+          ]
+        }
       }
     }
   ]

--- a/mock-server/data/compound_95.json
+++ b/mock-server/data/compound_95.json
@@ -96,6 +96,16 @@
         "shortName": "Section B - Subsides obtenus",
         "createdAt": "2019-07-09T06:55:49.128Z",
         "updatedAt": "2019-07-09T06:58:17.519Z"
+      },
+      "relationships": {
+        "formulaMappings": {
+          "data": [
+            {
+              "id": "4775",
+              "type": "formulaMapping"
+            }
+          ]
+        }
       }
     },
     {
@@ -111,6 +121,16 @@
         "shortName": "Section A - Subsides obtenus",
         "createdAt": "2019-07-09T06:54:20.412Z",
         "updatedAt": "2019-07-09T06:58:17.528Z"
+      },
+      "relationships": {
+        "formulaMappings": {
+          "data": [
+            {
+              "id": "4774",
+              "type": "formulaMapping"
+            }
+          ]
+        }
       }
     },
     {
@@ -126,6 +146,16 @@
         "shortName": "Section C - Subsides obtenus",
         "createdAt": "2019-07-09T06:58:17.535Z",
         "updatedAt": "2019-07-09T06:58:17.535Z"
+      },
+      "relationships": {
+        "formulaMappings": {
+          "data": [
+            {
+              "id": "4776",
+              "type": "formulaMapping"
+            }
+          ]
+        }
       }
     },
     {
@@ -141,6 +171,16 @@
         "shortName": "total",
         "createdAt": "2019-07-09T06:58:17.541Z",
         "updatedAt": "2019-07-09T06:58:17.541Z"
+      },
+      "relationships": {
+        "formulaMappings": {
+          "data": [
+            {
+              "id": "4814",
+              "type": "formulaMapping"
+            }
+          ]
+        }
       }
     }
   ]

--- a/mock-server/data/compounds.json
+++ b/mock-server/data/compounds.json
@@ -589,6 +589,16 @@
         "shortName": "Total Qualité",
         "createdAt": "2019-04-23T12:02:50.731Z",
         "updatedAt": "2019-05-15T09:44:01.771Z"
+      },
+      "relationships": {
+        "formulaMappings": {
+          "data": [
+            {
+              "id": "4026",
+              "type": "formulaMapping"
+            }
+          ]
+        }
       }
     },
     {
@@ -604,6 +614,16 @@
         "shortName": "total",
         "createdAt": "2019-04-04T11:23:04.430Z",
         "updatedAt": "2019-05-11T17:01:39.625Z"
+      },
+      "relationships": {
+        "formulaMappings": {
+          "data": [
+            {
+              "id": "4021",
+              "type": "formulaMapping"
+            }
+          ]
+        }
       }
     },
     {
@@ -619,6 +639,16 @@
         "shortName": "Qualité Globale",
         "createdAt": "2019-05-11T16:41:29.416Z",
         "updatedAt": "2019-05-15T07:31:54.436Z"
+      },
+      "relationships": {
+        "formulaMappings": {
+          "data": [
+            {
+              "id": "4160",
+              "type": "formulaMapping"
+            }
+          ]
+        }
       }
     },
     {
@@ -634,6 +664,16 @@
         "shortName": "b_total_subsidies",
         "createdAt": "2019-05-15T09:44:01.783Z",
         "updatedAt": "2019-05-15T09:44:01.783Z"
+      },
+      "relationships": {
+        "formulaMappings": {
+          "data": [
+            {
+              "id": "4184",
+              "type": "formulaMapping"
+            }
+          ]
+        }
       }
     },
     {
@@ -649,6 +689,16 @@
         "shortName": "total",
         "createdAt": "2019-05-23T08:56:38.810Z",
         "updatedAt": "2019-06-03T08:49:52.643Z"
+      },
+      "relationships": {
+        "formulaMappings": {
+          "data": [
+            {
+              "id": "4347",
+              "type": "formulaMapping"
+            }
+          ]
+        }
       }
     },
     {
@@ -664,6 +714,16 @@
         "shortName": "PTD - Subsides obtenus pour la Section A",
         "createdAt": "2019-05-22T14:10:22.756Z",
         "updatedAt": "2019-05-28T08:39:45.207Z"
+      },
+      "relationships": {
+        "formulaMappings": {
+          "data": [
+            {
+              "id": "4346",
+              "type": "formulaMapping"
+            }
+          ]
+        }
       }
     },
     {
@@ -679,6 +739,16 @@
         "shortName": "PTD - Subsides obtenus pour la Section B",
         "createdAt": "2019-05-29T09:03:50.029Z",
         "updatedAt": "2019-05-29T09:03:50.029Z"
+      },
+      "relationships": {
+        "formulaMappings": {
+          "data": [
+            {
+              "id": "4520",
+              "type": "formulaMapping"
+            }
+          ]
+        }
       }
     },
     {
@@ -694,6 +764,16 @@
         "shortName": "PTD - Subsides obtenus pour la Section C",
         "createdAt": "2019-06-03T08:49:52.650Z",
         "updatedAt": "2019-06-03T08:49:52.650Z"
+      },
+      "relationships": {
+        "formulaMappings": {
+          "data": [
+            {
+              "id": "4521",
+              "type": "formulaMapping"
+            }
+          ]
+        }
       }
     },
     {
@@ -709,6 +789,16 @@
         "shortName": "total",
         "createdAt": "2019-06-11T10:03:15.980Z",
         "updatedAt": "2019-06-11T10:03:15.980Z"
+      },
+      "relationships": {
+        "formulaMappings": {
+          "data": [
+            {
+              "id": "4603",
+              "type": "formulaMapping"
+            }
+          ]
+        }
       }
     },
     {
@@ -724,6 +814,16 @@
         "shortName": "PTSD - A Subsides Obtenus",
         "createdAt": "2019-06-11T10:00:55.986Z",
         "updatedAt": "2019-06-18T06:36:06.133Z"
+      },
+      "relationships": {
+        "formulaMappings": {
+          "data": [
+            {
+              "id": "4600",
+              "type": "formulaMapping"
+            }
+          ]
+        }
       }
     },
     {
@@ -739,6 +839,16 @@
         "shortName": "PTSD - B Subsides Obtenus",
         "createdAt": "2019-06-11T09:42:46.569Z",
         "updatedAt": "2019-06-18T06:36:06.145Z"
+      },
+      "relationships": {
+        "formulaMappings": {
+          "data": [
+            {
+              "id": "4601",
+              "type": "formulaMapping"
+            }
+          ]
+        }
       }
     },
     {
@@ -754,6 +864,16 @@
         "shortName": "PTSD - C Subsides Obtenus",
         "createdAt": "2019-06-11T10:02:34.020Z",
         "updatedAt": "2019-06-18T06:36:35.696Z"
+      },
+      "relationships": {
+        "formulaMappings": {
+          "data": [
+            {
+              "id": "4602",
+              "type": "formulaMapping"
+            }
+          ]
+        }
       }
     },
     {
@@ -769,6 +889,16 @@
         "shortName": "total",
         "createdAt": "2019-06-14T14:04:06.579Z",
         "updatedAt": "2019-06-18T10:15:47.827Z"
+      },
+      "relationships": {
+        "formulaMappings": {
+          "data": [
+            {
+              "id": "4684",
+              "type": "formulaMapping"
+            }
+          ]
+        }
       }
     },
     {
@@ -784,6 +914,16 @@
         "shortName": "INSPOOL - Subsides obtenus pour la Section C",
         "createdAt": "2019-06-14T14:04:06.571Z",
         "updatedAt": "2019-06-18T10:15:47.839Z"
+      },
+      "relationships": {
+        "formulaMappings": {
+          "data": [
+            {
+              "id": "4683",
+              "type": "formulaMapping"
+            }
+          ]
+        }
       }
     },
     {
@@ -799,6 +939,16 @@
         "shortName": "INSPOOL - Subsides obtenus pour la Section B",
         "createdAt": "2019-06-14T14:04:06.563Z",
         "updatedAt": "2019-06-18T10:15:47.849Z"
+      },
+      "relationships": {
+        "formulaMappings": {
+          "data": [
+            {
+              "id": "4682",
+              "type": "formulaMapping"
+            }
+          ]
+        }
       }
     },
     {
@@ -814,6 +964,16 @@
         "shortName": "INSPOOL - Subsides obtenus pour la Section A",
         "createdAt": "2019-06-14T14:04:06.555Z",
         "updatedAt": "2019-06-18T10:15:47.859Z"
+      },
+      "relationships": {
+        "formulaMappings": {
+          "data": [
+            {
+              "id": "4681",
+              "type": "formulaMapping"
+            }
+          ]
+        }
       }
     },
     {
@@ -829,6 +989,16 @@
         "shortName": "total",
         "createdAt": "2019-06-26T05:48:57.525Z",
         "updatedAt": "2019-06-26T15:25:30.472Z"
+      },
+      "relationships": {
+        "formulaMappings": {
+          "data": [
+            {
+              "id": "4695",
+              "type": "formulaMapping"
+            }
+          ]
+        }
       }
     },
     {
@@ -844,6 +1014,16 @@
         "shortName": "IPP - Subsides obtenus pour la Section A",
         "createdAt": "2019-06-26T15:25:30.483Z",
         "updatedAt": "2019-06-26T15:25:30.483Z"
+      },
+      "relationships": {
+        "formulaMappings": {
+          "data": [
+            {
+              "id": "4692",
+              "type": "formulaMapping"
+            }
+          ]
+        }
       }
     },
     {
@@ -859,6 +1039,16 @@
         "shortName": "IPP - Subsides obtenus pour la Section B",
         "createdAt": "2019-06-26T15:25:30.490Z",
         "updatedAt": "2019-06-26T15:25:30.490Z"
+      },
+      "relationships": {
+        "formulaMappings": {
+          "data": [
+            {
+              "id": "4693",
+              "type": "formulaMapping"
+            }
+          ]
+        }
       }
     },
     {
@@ -874,6 +1064,16 @@
         "shortName": "IPP - Subsides obtenus pour la Section C",
         "createdAt": "2019-06-26T15:25:30.497Z",
         "updatedAt": "2019-06-26T15:25:30.497Z"
+      },
+      "relationships": {
+        "formulaMappings": {
+          "data": [
+            {
+              "id": "4694",
+              "type": "formulaMapping"
+            }
+          ]
+        }
       }
     },
     {
@@ -889,6 +1089,16 @@
         "shortName": "Section B - Subsides obtenus",
         "createdAt": "2019-07-09T06:55:49.128Z",
         "updatedAt": "2019-07-09T06:58:17.519Z"
+      },
+      "relationships": {
+        "formulaMappings": {
+          "data": [
+            {
+              "id": "4775",
+              "type": "formulaMapping"
+            }
+          ]
+        }
       }
     },
     {
@@ -904,6 +1114,16 @@
         "shortName": "Section A - Subsides obtenus",
         "createdAt": "2019-07-09T06:54:20.412Z",
         "updatedAt": "2019-07-09T06:58:17.528Z"
+      },
+      "relationships": {
+        "formulaMappings": {
+          "data": [
+            {
+              "id": "4774",
+              "type": "formulaMapping"
+            }
+          ]
+        }
       }
     },
     {
@@ -919,6 +1139,16 @@
         "shortName": "Section C - Subsides obtenus",
         "createdAt": "2019-07-09T06:58:17.535Z",
         "updatedAt": "2019-07-09T06:58:17.535Z"
+      },
+      "relationships": {
+        "formulaMappings": {
+          "data": [
+            {
+              "id": "4776",
+              "type": "formulaMapping"
+            }
+          ]
+        }
       }
     },
     {
@@ -934,6 +1164,16 @@
         "shortName": "total",
         "createdAt": "2019-07-09T06:58:17.541Z",
         "updatedAt": "2019-07-09T06:58:17.541Z"
+      },
+      "relationships": {
+        "formulaMappings": {
+          "data": [
+            {
+              "id": "4814",
+              "type": "formulaMapping"
+            }
+          ]
+        }
       }
     }
   ]

--- a/mock-server/data/set_187.json
+++ b/mock-server/data/set_187.json
@@ -174,21 +174,24 @@
         "stableId": "70c62d76-376c-4547-bb0e-ecca0e799725"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "3848",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "3849",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "3852",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -204,21 +207,24 @@
         "stableId": "a0783b4f-f983-463c-b14f-b4e6a1301647"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "3850",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "3851",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "3853",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -234,21 +240,24 @@
         "stableId": "2e4aa95d-40b8-4f92-8c63-bc95f9fd6a98"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "3854",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "3855",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "3856",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -264,21 +273,24 @@
         "stableId": "3e70a255-d16b-4b98-86b3-0f7d68d9e9ad"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "3857",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "3858",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "3863",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -294,21 +306,24 @@
         "stableId": "5a4a9ed8-0fd8-440a-bca6-3fef783c4c66"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "3859",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "3860",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "3864",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -324,21 +339,24 @@
         "stableId": "42bab832-a90f-466b-9464-b8cb6c1f254e"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "3861",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "3862",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "3865",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -354,21 +372,24 @@
         "stableId": "bb102ac5-50b3-4fb0-bd6e-a3679f61e69d"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "3866",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "3867",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "3878",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -384,21 +405,24 @@
         "stableId": "0af37adb-ccaf-4883-a3ff-609b379d6004"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "3868",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "3869",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "3879",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -414,21 +438,24 @@
         "stableId": "0c57d55b-bd3d-4226-9a52-21765c0e51ff"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "3870",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "3871",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "3880",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -444,21 +471,24 @@
         "stableId": "1e76535f-3dde-4dfe-a80c-467d2ebd0272"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "3872",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "3873",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "3881",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -474,21 +504,24 @@
         "stableId": "b5a58216-bc27-4bcd-b76e-84e3b02ae3de"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "3874",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "3875",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "3882",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -504,21 +537,924 @@
         "stableId": "493305b4-14fd-42b6-b920-b192a3e11e92"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "3876",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "3877",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "3883",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "3848",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "Effectifs - Vérifié - Fille, 1ère année",
+        "origin": "dataValueSets",
+        "stableId": "1b2c9acf-bce4-49e3-a22a-ab79581053e3",
+        "kind": "data_element_coc"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "rYVb2bQlURu.UTXVZzPwGjA",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "320",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "3849",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "Effectifs - Déclaré - Fille, 1ère année",
+        "origin": "dataValueSets",
+        "stableId": "2d5ff1a0-0635-40f7-839a-e999948fac5c",
+        "kind": "data_element_coc"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "KgBGVpWCXvN.UTXVZzPwGjA",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "321",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "3852",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "Fille, 1ère année - PU config",
+        "origin": "dataValueSets",
+        "stableId": "524f2d70-c679-41f9-8def-29c4dd563d74",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "Y2DAc1eDwUT",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "322",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "3850",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "Effectifs - Déclaré - Fille, 2ème année",
+        "origin": "dataValueSets",
+        "stableId": "67f2569a-ed8c-4751-ab7c-1a7c471ca605",
+        "kind": "data_element_coc"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "KgBGVpWCXvN.MH7HanPmz6V",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "321",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "3851",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "Effectifs - Vérifié - Fille, 2ème année",
+        "origin": "dataValueSets",
+        "stableId": "2a93d536-0e69-474f-a4e7-cfeaf2e4070b",
+        "kind": "data_element_coc"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "rYVb2bQlURu.MH7HanPmz6V",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "320",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "3853",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "Fille, 2e année - PU config",
+        "origin": "dataValueSets",
+        "stableId": "958cd1c5-fbe2-401a-b75c-bb7bc74c768c",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "Pa6GYruYOAD",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "322",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "3854",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "Effectifs - Déclaré - Fille, 3ème année",
+        "origin": "dataValueSets",
+        "stableId": "9b266cef-db5b-42ad-8297-2f666864bce6",
+        "kind": "data_element_coc"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "KgBGVpWCXvN.DfjHgHCnnSG",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "321",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "3855",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "Effectifs - Vérifié - Fille, 3ème année",
+        "origin": "dataValueSets",
+        "stableId": "111f9dc5-e3da-403b-9012-5ed63e02d6d9",
+        "kind": "data_element_coc"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "rYVb2bQlURu.DfjHgHCnnSG",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "320",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "3856",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "Fille, 3e année - PU config",
+        "origin": "dataValueSets",
+        "stableId": "93ed6c48-dc2f-4e6d-b78b-2c3dde9635cf",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "L2J2hX9Xgiy",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "322",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "3857",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "Effectifs - Déclaré - Fille, 4ème année",
+        "origin": "dataValueSets",
+        "stableId": "63d5c3f9-f906-4923-9d7f-52aadfb349ae",
+        "kind": "data_element_coc"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "KgBGVpWCXvN.dQyVk3a8ZRK",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "321",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "3858",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "Effectifs - Vérifié - Fille, 4ème année",
+        "origin": "dataValueSets",
+        "stableId": "8da78be5-ba2e-46a7-8f2e-16a12f98215f",
+        "kind": "data_element_coc"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "rYVb2bQlURu.dQyVk3a8ZRK",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "320",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "3863",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "Fille, 4e année - PU config",
+        "origin": "dataValueSets",
+        "stableId": "9be67f66-2b70-4c93-a600-0779ed2d6cbb",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "obu1vV8wetK",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "322",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "3859",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "Effectifs - Déclaré - Fille, 5ème année",
+        "origin": "dataValueSets",
+        "stableId": "85a1135b-80ad-409c-bc22-daae5a3d0590",
+        "kind": "data_element_coc"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "KgBGVpWCXvN.Opzj9ZD5orM",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "321",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "3860",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "Effectifs - Vérifié - Fille, 5ème année",
+        "origin": "dataValueSets",
+        "stableId": "3b01d844-5168-495a-b17f-271748551afb",
+        "kind": "data_element_coc"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "rYVb2bQlURu.Opzj9ZD5orM",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "320",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "3864",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "Fille, 5e année - PU config",
+        "origin": "dataValueSets",
+        "stableId": "cc508377-37e6-4f7f-8c8b-312da5fb0d54",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "mDyOJdGFblz",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "322",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "3861",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "Effectifs - Déclaré - Fille, 6ème année",
+        "origin": "dataValueSets",
+        "stableId": "5e20fce1-52f6-4583-a3b3-dd8e99084803",
+        "kind": "data_element_coc"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "KgBGVpWCXvN.XdGVoLRUbXN",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "321",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "3862",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "Effectifs - Vérifié - Fille, 6ème année",
+        "origin": "dataValueSets",
+        "stableId": "c991e8e2-6366-4884-88e6-b789782a2f78",
+        "kind": "data_element_coc"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "rYVb2bQlURu.XdGVoLRUbXN",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "320",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "3865",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "Fille, 6e année - PU config",
+        "origin": "dataValueSets",
+        "stableId": "113d01e6-6ca7-44d0-a2de-aa276906d012",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "KgaSXwVTbsP",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "322",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "3866",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "Effectifs - Déclaré - Garçon, 1ère année",
+        "origin": "dataValueSets",
+        "stableId": "8c9d6eca-0050-45a1-9177-3f11491a1549",
+        "kind": "data_element_coc"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "KgBGVpWCXvN.kzM8keD9QHw",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "321",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "3867",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "Effectifs - Vérifié - Garçon, 1ère année",
+        "origin": "dataValueSets",
+        "stableId": "9e83c317-00eb-48b8-afac-e37ad5462ffb",
+        "kind": "data_element_coc"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "rYVb2bQlURu.kzM8keD9QHw",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "320",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "3878",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "Garçon, 1ère année - PU config",
+        "origin": "dataValueSets",
+        "stableId": "17cc3c2d-c833-471d-8bcf-965127898e83",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "F4aTxtzg4hb",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "322",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "3868",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "Effectifs - Déclaré - Garçon, 2ème année",
+        "origin": "dataValueSets",
+        "stableId": "94c310f3-c988-4636-8be2-bad6d9654bd6",
+        "kind": "data_element_coc"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "KgBGVpWCXvN.wAQLv6OU2dV",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "321",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "3869",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "Effectifs - Vérifié - Garçon, 2ème année",
+        "origin": "dataValueSets",
+        "stableId": "a024e6ea-44f7-4c59-ab9d-18d9152d3cfa",
+        "kind": "data_element_coc"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "rYVb2bQlURu.wAQLv6OU2dV",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "320",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "3879",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "Garçon, 2e année - PU config",
+        "origin": "dataValueSets",
+        "stableId": "e4ccb098-cda9-4961-b87d-9a15b792f8fc",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "O0kfPrt3jkl",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "322",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "3870",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "Effectifs - Déclaré - Garçon, 3ème année",
+        "origin": "dataValueSets",
+        "stableId": "a96f8102-dc4f-41f9-b9cd-a9507d507952",
+        "kind": "data_element_coc"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "KgBGVpWCXvN.A9nEIRv7yW1",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "321",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "3871",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "Effectifs - Vérifié - Garçon, 3ème année",
+        "origin": "dataValueSets",
+        "stableId": "84bed66d-f820-40ec-94f1-83bed0ca3b4a",
+        "kind": "data_element_coc"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "rYVb2bQlURu.A9nEIRv7yW1",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "320",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "3880",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "Garçon, 3e année - PU config",
+        "origin": "dataValueSets",
+        "stableId": "c50d733e-1a85-4c6b-aac3-bec94e0d9d7f",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "x4XBgI1ViXB",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "322",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "3872",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "Effectifs - Déclaré - Garçon, 4ème année",
+        "origin": "dataValueSets",
+        "stableId": "a24a6d1b-3ebd-47ae-91b9-7dc1e439b7f1",
+        "kind": "data_element_coc"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "KgBGVpWCXvN.ejBSDcp6NvA",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "321",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "3873",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "Effectifs - Vérifié - Garçon, 4ème année",
+        "origin": "dataValueSets",
+        "stableId": "98ca2b94-df7d-4787-8000-b000c913c8d8",
+        "kind": "data_element_coc"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "rYVb2bQlURu.ejBSDcp6NvA",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "320",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "3881",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "Garçon, 4e année - PU config",
+        "origin": "dataValueSets",
+        "stableId": "43e150f1-43f7-45d6-867a-ae3192b18b58",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "yDxtqvScKWs",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "322",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "3874",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "Effectifs - Déclaré - Garçon, 5ème année",
+        "origin": "dataValueSets",
+        "stableId": "74049d24-944f-47fa-908f-e119a159f291",
+        "kind": "data_element_coc"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "KgBGVpWCXvN.mQvCrIht3K6",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "321",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "3875",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "Effectifs - Vérifié - Garçon, 5ème année",
+        "origin": "dataValueSets",
+        "stableId": "74e193a9-f8b7-4090-853d-837c76abffbc",
+        "kind": "data_element_coc"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "rYVb2bQlURu.mQvCrIht3K6",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "320",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "3882",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "Garçon, 5e année - PU config",
+        "origin": "dataValueSets",
+        "stableId": "1c5fc710-396b-4c23-a908-3f680c24e103",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "JDCzEDUvBF3",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "322",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "3876",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "Effectifs - Déclaré - Garçon, 6ème année",
+        "origin": "dataValueSets",
+        "stableId": "853a35ab-0119-49af-b906-717a0d15bb3b",
+        "kind": "data_element_coc"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "KgBGVpWCXvN.egm5rOCk7dw",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "321",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "3877",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "Effectifs - Vérifié - Garçon, 6ème année",
+        "origin": "dataValueSets",
+        "stableId": "5d229141-8cfe-4fa8-b376-f95b971be142",
+        "kind": "data_element_coc"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "rYVb2bQlURu.egm5rOCk7dw",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "320",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "3883",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "Garçon, 6e année - PU config",
+        "origin": "dataValueSets",
+        "stableId": "4913ce93-f2b8-4fb2-820c-e980a1a2d512",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "l8aNXhnolKf",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "322",
+            "type": "input"
+          }
         }
       }
     }

--- a/mock-server/data/set_190.json
+++ b/mock-server/data/set_190.json
@@ -138,21 +138,24 @@
         "stableId": "f95b7992-ad5a-4a10-b7c0-7b72479e1ffb"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "3972",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4008",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4015",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -168,17 +171,20 @@
         "stableId": "41b41a5d-2d31-47db-ad1c-cc943a5ef376"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "3973",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4009",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -194,17 +200,20 @@
         "stableId": "a953ddaf-9d21-490b-8c52-0026c7a9fa25"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "3974",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4010",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -220,17 +229,245 @@
         "stableId": "37cd0727-b715-44c0-9591-04248b42de46"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "3975",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4011",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "3972",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "B.1.1 - Latrines filles - Palier atteint - ver",
+        "origin": "dataValueSets",
+        "stableId": "70332faf-5319-4d8c-8443-ab4833cfed82",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "Rmmxj60NodW",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "328",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "4008",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "B.1.1 - Latrines filles max points",
+        "origin": "dataValueSets",
+        "stableId": "3746ea19-ec13-49bd-b076-2aa73ac7e9af",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "ByGGSv0DUY4",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "330",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "4015",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "PBF - Budget Disponible Definition - B1",
+        "origin": "dataValueSets",
+        "stableId": "082d77f9-02dd-4629-9e33-2d1948e60a1d",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "qMRe0tzGt97",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "332",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "3973",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "B.1.2 - Latrines garçons - Palier atteint - ver",
+        "origin": "dataValueSets",
+        "stableId": "630b0c2a-0f40-4921-b729-bea0018fb966",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "Zhpao38tMMe",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "328",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "4009",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "B.1.2 - Latrines garçons max points",
+        "origin": "dataValueSets",
+        "stableId": "ed710c64-2f28-407a-9068-285ae96d9313",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "StKvwLmpF64",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "330",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "3974",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "B.1.3 - Disponibilité eau potable - ver",
+        "origin": "dataValueSets",
+        "stableId": "388e00f6-1ade-4b09-9464-2cf457faf051",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "bGP4dEptlBD",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "328",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "4010",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "B.1.3 - Disponibilité eau potable - max points",
+        "origin": "dataValueSets",
+        "stableId": "576c7838-ee3a-475f-add8-728cc1379215",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "b8ZJ7rhpYrW",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "330",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "3975",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "B.1.4 - Présence de clôture - ver",
+        "origin": "dataValueSets",
+        "stableId": "e3767f83-753e-4aab-83b2-9f686be76611",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "Qhn0wWx6ena",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "328",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "4011",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "B.1.4 - Présence de clôture - max points",
+        "origin": "dataValueSets",
+        "stableId": "8006fbfc-bd36-4f58-9ff5-d88917ba699d",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "uUoOWBUlI5l",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "330",
+            "type": "input"
+          }
         }
       }
     }

--- a/mock-server/data/set_193.json
+++ b/mock-server/data/set_193.json
@@ -134,21 +134,24 @@
         "stableId": "3bc66320-5edc-4a74-8da6-cf96ceb842e2"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "3976",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4014",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4016",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -164,17 +167,20 @@
         "stableId": "78f3519d-6d51-4c6e-a1a4-af52c13cc3d8"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "3977",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4017",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -190,17 +196,195 @@
         "stableId": "fae70187-dd71-4c49-89ca-d91a602a02d3"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "3978",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4018",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "3976",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "B.2.1 Tableau noir ou vert avec craies dans chaque salle de classe ? - ver",
+        "origin": "dataValueSets",
+        "stableId": "2b7e0605-7941-4ea9-ac04-80231114be83",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "sdiddRsreAX",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "328",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "4014",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "B.2.1 Tableau noir ou vert avec craies dans chaque salle de classe - max points",
+        "origin": "dataValueSets",
+        "stableId": "f2f3b926-7b75-4530-8a5f-72c4dd3c211c",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "luyzpAVOPdP",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "330",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "4016",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "PBF - Budget Disponible Definition B.2",
+        "origin": "dataValueSets",
+        "stableId": "cae7b665-6778-4eff-bd87-9717dbb3ccb2",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "GBwuX5AxzGT",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "332",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "3977",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "B.2.2 Il y a des matériels didactiques affichés sur les murs de toutes les salles - ver",
+        "origin": "dataValueSets",
+        "stableId": "2f89596b-696b-4438-978b-487a945b273e",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "B1jaNtJbauu",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "328",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "4017",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "B.2.2 Il y a des matériels didactiques affichés sur les murs de toutes les salles - max points",
+        "origin": "dataValueSets",
+        "stableId": "6cdc55ff-abef-4a90-8241-933ab7115f3b",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "oQZYVTe8Vkz",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "330",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "3978",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "B.2.3 Nombre de pupitres de l'école - palier atteint - ver",
+        "origin": "dataValueSets",
+        "stableId": "bdb33446-e832-40c5-8fc4-25818520d4a2",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "sMQ3FeuRqY3",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "328",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "4018",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "B.2.3 Nombre de pupitres de l'école (donnez le nombre de pupitres disponibles) - max points",
+        "origin": "dataValueSets",
+        "stableId": "42754b25-19e3-480c-bcbe-5834881b8ae3",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "Da7VMX4lJah",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "330",
+            "type": "input"
+          }
         }
       }
     }

--- a/mock-server/data/set_194.json
+++ b/mock-server/data/set_194.json
@@ -130,21 +130,24 @@
         "stableId": "88ff5257-e8ec-458d-acbb-9fd92a38ae8b"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "3996",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4019",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4020",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -160,17 +163,145 @@
         "stableId": "d779bf48-9862-4eb4-9c3a-586fcf1ae8c4"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "3997",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4021",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "3996",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "B.3.6 Taux de ponctualité - palier atteint - ver",
+        "origin": "dataValueSets",
+        "stableId": "dcefa2bb-ebc7-4a75-a8ca-c785dc579500",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "ZzzjoD2q1Xu",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "328",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "4019",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "PBF - Budget Disponible Definition - B.3",
+        "origin": "dataValueSets",
+        "stableId": "994737ed-7acb-4236-b9f1-1db090924986",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "G4oHS9v1us0",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "332",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "4020",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "B.3.6 Taux de ponctualité - max points",
+        "origin": "dataValueSets",
+        "stableId": "80059247-1a10-4f65-be01-d90cc76698d6",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "NdEL1Y2y8wj",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "330",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "3997",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "B.3.5 Taux de régularité - palier atteint - ver",
+        "origin": "dataValueSets",
+        "stableId": "526370d7-dd8e-4652-81cc-9a35776904d7",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "m8ugULHOjxw",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "328",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "4021",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "B.3.5 Taux de régularité - max points",
+        "origin": "dataValueSets",
+        "stableId": "29bf8620-2b60-45ef-9cf5-4b4d46ed4735",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "TwzBOU47iuU",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "330",
+            "type": "input"
+          }
         }
       }
     }

--- a/mock-server/data/set_197.json
+++ b/mock-server/data/set_197.json
@@ -130,21 +130,24 @@
         "stableId": "37f0ddf4-b6a1-49a9-9ff6-7560cd907b8f"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "3998",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4022",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4023",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -160,17 +163,145 @@
         "stableId": "79b146ad-3b6a-4054-9667-f22510a3c621"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "3999",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4024",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "3998",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "B.4.1 Organisation des réunions d’unités pédagogiques au sein de l’école - palier atteint - ver",
+        "origin": "dataValueSets",
+        "stableId": "0403c5ca-e318-4349-afbf-a12f19e76fce",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "u5fpv3DNY3V",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "328",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "4022",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "B.4.1 Organisation des réunions d’unités pédagogiques au sein de l’école - max points",
+        "origin": "dataValueSets",
+        "stableId": "d4436d2f-b29d-43d6-8a5c-eb02ac0e3708",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "t2bMQQPyQA2",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "330",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "4023",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "PBF - Budget Disponible Definition - B.4",
+        "origin": "dataValueSets",
+        "stableId": "08e1ad37-e37f-4ae5-8fc1-a2d570dd3739",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "qxIv469h7zP",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "332",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "3999",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "B.4.2 Nombre de REP organisée pour le trimestre (Au moins une rencontre d’échange par mois entre les enseignants des écoles de proximité) - palier atteint - ver",
+        "origin": "dataValueSets",
+        "stableId": "4d07a0fc-2b85-4a4d-84b7-9f7aeaa71899",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "DlJRjNb70kO",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "328",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "4024",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "B.4.2 Nombre de REP organisée pour le trimestre (Au moins une rencontre d’échange par mois entre les enseignants des écoles de proximité) - max points",
+        "origin": "dataValueSets",
+        "stableId": "b06a83e8-f280-4815-870b-46a95e2a98fc",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "KssGSa9LaaQ",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "330",
+            "type": "input"
+          }
         }
       }
     }

--- a/mock-server/data/set_198.json
+++ b/mock-server/data/set_198.json
@@ -130,21 +130,24 @@
         "stableId": "865f94b7-dd66-46ca-b745-1b84ea5e4cd3"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4000",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4025",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4026",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -160,17 +163,145 @@
         "stableId": "92a6074c-535d-4fb0-b3b9-5407b66cb90d"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4001",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4027",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "4000",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "B.5.1 Nombre de visites de classe effectuées par le Directeur au courant du trimestre - palier atteint - ver",
+        "origin": "dataValueSets",
+        "stableId": "9d2353e3-5224-4d6b-8a9c-7fb04c2e2db7",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "KzHi0N7LQcH",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "328",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "4025",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "B.5.1 Nombre de visites de classe effectuées par le Directeur au courant du trimestre - max points",
+        "origin": "dataValueSets",
+        "stableId": "599e3280-2745-4d2e-9c49-cb024182cfc0",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "imLxZ28J31w",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "330",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "4026",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "PBF - Budget Disponible Definition - B.5",
+        "origin": "dataValueSets",
+        "stableId": "2d1d46e9-cd2f-46ec-823a-2d5072837717",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "sQsk1VcmIsY",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "332",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "4001",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "B.5.2 Nombre des réunions de cellule de base tenues par le directeur par mois - palier atteint - ver",
+        "origin": "dataValueSets",
+        "stableId": "2c349b51-1770-4360-9e21-07f2a4d802c7",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "cwpKOu0MHdy",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "328",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "4027",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "B.5.2 Nombre des réunions de cellule de base tenues par le directeur par mois - max points",
+        "origin": "dataValueSets",
+        "stableId": "5c6101a8-ae5d-4017-acc8-c943e5d5855d",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "QOYQV2loeMO",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "330",
+            "type": "input"
+          }
         }
       }
     }

--- a/mock-server/data/set_199.json
+++ b/mock-server/data/set_199.json
@@ -134,21 +134,24 @@
         "stableId": "0b72fb08-1d8e-447a-b979-eab073f8742d"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4002",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4028",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4029",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -164,17 +167,20 @@
         "stableId": "f4cd0ba1-9a99-4717-8c62-ff6f11f7f4b8"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4003",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4030",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -190,17 +196,195 @@
         "stableId": "9dcc2d93-bbd5-465d-a60c-369e691fbb9c"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4004",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4031",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "4002",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "B.6.1 Les manuels scolaires par élève et par branche (Mathématique et Français) sont disponibles - ver",
+        "origin": "dataValueSets",
+        "stableId": "6ee79151-52e0-4bbf-a12a-2b03a984228b",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "uMFsm2ZYbsC",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "328",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "4028",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "B.6.1 Les manuels scolaires par élève et par branche (Mathématique et Français) sont disponibles - max points",
+        "origin": "dataValueSets",
+        "stableId": "5fb5d581-4b83-42d0-a302-30e427721984",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "fToPRfewn9T",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "330",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "4029",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "PBF - Budget Disponible Definition - B.6",
+        "origin": "dataValueSets",
+        "stableId": "2c0a7181-c76d-4afa-9c60-98ed9b4a9129",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "U0uvkOdIREu",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "332",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "4003",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "B.6.2 Tous les élèves retirent et remettent les livres en bon état - ver",
+        "origin": "dataValueSets",
+        "stableId": "be0a75a9-15ba-4446-858c-dfe95f847d32",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "lps8iF8toan",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "328",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "4030",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "B.6.2 Tous les élèves retirent et remettent les livres en bon état - max points",
+        "origin": "dataValueSets",
+        "stableId": "b497cb23-b0ff-42cb-9adc-8bc12b23edb7",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "VCBz9piDZfA",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "330",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "4004",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "B.6.3 Pourcentage des parents ou membres de famille qui assistent les élèves à faire le devoir à domicile (Signature des parents/membres familles dans les cahiers de devoir) - palier atteint - ver",
+        "origin": "dataValueSets",
+        "stableId": "54c756fe-5163-44da-ae90-dbabfba18a94",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "qOHmxkZLbId",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "328",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "4031",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "B.6.3 Pourcentage des parents ou membres de famille qui assistent les élèves à faire le devoir à domicile (Signature des parents/membres familles dans les cahiers de devoir) - max points",
+        "origin": "dataValueSets",
+        "stableId": "1d463929-4fba-4691-bc7d-e7a15cde3c40",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "Iaug8NP10dR",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "330",
+            "type": "input"
+          }
         }
       }
     }

--- a/mock-server/data/set_200.json
+++ b/mock-server/data/set_200.json
@@ -126,21 +126,99 @@
         "stableId": "a3e1d112-c933-4769-9ce1-38d7acc79327"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4005",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4032",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4033",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "4005",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "B.7.1 Tous les cahiers de devoir des élèves sont contrôlés par l’enseignant - ver",
+        "origin": "dataValueSets",
+        "stableId": "3c8e1e8f-965a-414b-ac92-f1777649e066",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "aJXDQE8Oj97",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "328",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "4032",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "B.7.1 Tous les cahiers de devoir des élèves sont contrôlés par l’enseignant - max points",
+        "origin": "dataValueSets",
+        "stableId": "20662520-b64d-464e-8c98-adf05bbf113d",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "JpyREr6XHzW",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "330",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "4033",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "PBF - Budget Disponible Definition - B.7",
+        "origin": "dataValueSets",
+        "stableId": "58b97665-2b82-4857-bff5-28632aee655d",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "UQuH209Qy5n",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "332",
+            "type": "input"
+          }
         }
       }
     }

--- a/mock-server/data/set_201.json
+++ b/mock-server/data/set_201.json
@@ -126,21 +126,99 @@
         "stableId": "e0fc8ef6-3a60-4d17-8771-f1790a2eb763"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4082",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4083",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4084",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "4082",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "B.8 - Total max points",
+        "origin": "dataValueSets",
+        "stableId": "d08402dc-7624-4349-8903-db3a00b32449",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "EQtIvPlNTWq",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "330",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "4083",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "PBF - Budget Disponible Definition - B.8 - Collaboration parents-école",
+        "origin": "dataValueSets",
+        "stableId": "af351803-e7d4-40bd-a8ba-df9d0df9214c",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "wWz9w5BVsZX",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "332",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "4084",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "B.8 - Palier atteint - ver",
+        "origin": "dataValueSets",
+        "stableId": "9865532d-ce18-4319-8a66-abc93155e50f",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "YNobeQtXR2i",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "328",
+            "type": "input"
+          }
         }
       }
     }

--- a/mock-server/data/set_202.json
+++ b/mock-server/data/set_202.json
@@ -170,21 +170,24 @@
         "stableId": "72273128-33c6-4f05-b698-54ded60e7157"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4085",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4086",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4087",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -200,17 +203,20 @@
         "stableId": "78662736-5ee8-4a33-9322-8e6f4fe9845f"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4088",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4089",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -226,17 +232,20 @@
         "stableId": "57a61f77-ab0b-47e2-b730-966d6a3654c0"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4090",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4091",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -252,17 +261,20 @@
         "stableId": "078115ad-6e09-44db-a85c-deae5b120ac4"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4092",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4093",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -278,17 +290,20 @@
         "stableId": "dcabc92a-6c45-4874-ad28-fd9e2ff228b3"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4094",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4095",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -304,17 +319,20 @@
         "stableId": "8e57a999-662f-4dc7-a34c-10e16d0291e3"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4096",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4097",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -330,17 +348,20 @@
         "stableId": "95bb08cb-630b-4d1f-8ff7-0ffa663d40b3"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4098",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4099",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -356,17 +377,20 @@
         "stableId": "60f056f2-0142-4515-b10f-cd4475e751d8"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4100",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4101",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -382,17 +406,20 @@
         "stableId": "a4f93013-072f-4a4d-b91d-df97918e70ed"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4102",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4103",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -408,17 +435,20 @@
         "stableId": "88e17bfc-6f3d-4c78-971b-49614370638e"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4104",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4105",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -434,17 +464,20 @@
         "stableId": "a5a8ca8a-65fd-4282-9ad2-1eec3c04d229"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4106",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4107",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -460,17 +493,645 @@
         "stableId": "24e0d48b-0f60-4a9e-ba13-abcaae1f4c37"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4108",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4109",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "4085",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "B.9.1 Règlement Intérieur existe et signé par tous les enseignants et affiché sur les murs de toutes les classes ? - max points",
+        "origin": "dataValueSets",
+        "stableId": "4d66d956-9edd-46de-9278-29ba8ed50cd9",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "rMCY15LMkoF",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "330",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "4086",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "B.9.1 Règlement Intérieur existe et signé par tous les enseignants et affiché sur les murs de toutes les classes ? - ver",
+        "origin": "dataValueSets",
+        "stableId": "3d836ea3-0eb0-43bb-81a7-7409c9911343",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "vkPywyMACW2",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "328",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "4087",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "PBF - Budget Disponible Definition - B.9 - Gouvernance Interne",
+        "origin": "dataValueSets",
+        "stableId": "5d1af6b4-7d12-4744-995b-d2ee5a9edd42",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "nlezjuSEQTE",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "332",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "4088",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "B.9.2.1 Existence de bon d'entrée caisse à jour - max points",
+        "origin": "dataValueSets",
+        "stableId": "0c6cb423-088a-4473-bd74-458cc9731894",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "yKIfrruI8Lc",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "330",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "4089",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "B.9.2.1 Existence de bon d'entrée caisse à jour - ver",
+        "origin": "dataValueSets",
+        "stableId": "0b71b6bf-8091-4a4b-a7f7-8456bb6f7004",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "zPAH8oR1R4q",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "328",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "4090",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "B.9.2.2 Existence de bon de sortie caisse à jour - max points",
+        "origin": "dataValueSets",
+        "stableId": "c7aa8a7d-0a24-456b-8c42-0334bb3ac307",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "XYBcYPTjiXY",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "330",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "4091",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "B.9.2.2 Existence de bon de sortie caisse à jour - ver",
+        "origin": "dataValueSets",
+        "stableId": "739aff51-8c16-44a6-a271-0c3873775a9a",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "WoVpPfoavCY",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "328",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "4092",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "B.9.2.3 Existence du livre de caisse à jour - max points",
+        "origin": "dataValueSets",
+        "stableId": "5ca3ed54-dbb0-4c4f-8a92-b157dfdfec80",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "JzuFcGqaZu5",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "330",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "4093",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "B.9.2.3 Existence du livre de caisse à jour - ver",
+        "origin": "dataValueSets",
+        "stableId": "a96531ad-be98-4390-898b-09337912fbb6",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "GAnmaBOoTyR",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "328",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "4094",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "B.9.2.4 Existence des classeurs des pièces justificatives - max points",
+        "origin": "dataValueSets",
+        "stableId": "0d1f28b7-b306-4fc4-a940-b74ca21a4a4e",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "fsKHyj7N5T7",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "330",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "4095",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "B.9.2.4 Existence des classeurs des pièces justificatives - ver",
+        "origin": "dataValueSets",
+        "stableId": "56367ada-371c-4324-b65b-ad3e17e0b9ad",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "m2uvpTdWx7Z",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "328",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "4096",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "B.9.2.5 Existence du rapport financier trimestriel signé - max points",
+        "origin": "dataValueSets",
+        "stableId": "2243131e-3d9b-4bcf-92df-06f30f7c380d",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "AVdlo7JcBFV",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "330",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "4097",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "B.9.2.5 Existence du rapport financier trimestriel signé - ver",
+        "origin": "dataValueSets",
+        "stableId": "fee18e13-b9f9-462f-8397-51be41fb33ae",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "qOMHbA4lYmv",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "328",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "4098",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "B.9.3 Présence des fiches d'évaluation des élèves par trimestre avec restitutions de l'enseignant et signée par un parent/tuteur - max points",
+        "origin": "dataValueSets",
+        "stableId": "3c808803-b180-458c-a935-30154b48fdcc",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "PrcieEvId0t",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "330",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "4099",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "B.9.3 Présence des fiches d'évaluation des élèves par trimestre avec restitutions de l'enseignant et signée par un parent/tuteur - ver",
+        "origin": "dataValueSets",
+        "stableId": "5252bd39-0cdd-48dd-80b5-c7333244e1b5",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "P13XQ7EEAYK",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "328",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "4100",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "B.9.4 Existence des statistiques scolaires complètes, promptes du dernier trimestre et transmises à la sous division - max points",
+        "origin": "dataValueSets",
+        "stableId": "6a84e275-7e8d-4fab-b6cd-598906eaee9e",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "VPpFzvNIdBi",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "330",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "4101",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "B.9.4 Existence des statistiques scolaires complètes, promptes du dernier trimestre et transmises à la sous division - ver",
+        "origin": "dataValueSets",
+        "stableId": "dfa524f0-d8fc-4e8a-8a44-91a0954777a1",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "h4h7qsLaNIN",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "328",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "4102",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "B.9.5 Tenue d'au moins 1 réunion mensuelle par l'équipe d'enseignants et directeur avec une liste de points d'action à améliorer - max points",
+        "origin": "dataValueSets",
+        "stableId": "5fce63ce-eebf-4ed3-b0c0-8844649f0fc4",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "we6Ue6tPwEG",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "330",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "4103",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "B.9.5 Tenue d'au moins 1 réunion mensuelle par l'équipe d'enseignants et directeur avec une liste de points d'action à améliorer - ver",
+        "origin": "dataValueSets",
+        "stableId": "c3f41479-fc29-4d54-b3da-b51841b40345",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "iTk2MFCm6vO",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "328",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "4104",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "B.9.6 Existence des rapports d’enquête communautaire réalisée par ASLO - max points",
+        "origin": "dataValueSets",
+        "stableId": "3555d1b3-262f-4c73-8d7a-29e476a0046c",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "HUYSn5OW9ka",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "330",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "4105",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "B.9.6 Existence des rapports d’enquête communautaire réalisée par ASLO - ver",
+        "origin": "dataValueSets",
+        "stableId": "57f4fc31-4cbf-4067-93b0-128aacaa429e",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "mPbNKEdpT8B",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "328",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "4106",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "B.9.7 Existence d'un plan de gestion des risques au sein de l'école - max points",
+        "origin": "dataValueSets",
+        "stableId": "a4f00c5f-1a57-460e-8be9-63b7228d5ee6",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "JJGhHg9zCSR",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "330",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "4107",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "B.9.7 Existence d'un plan de gestion des risques au sein de l'école - ver",
+        "origin": "dataValueSets",
+        "stableId": "b27bf8c0-7a3d-49a8-9e7c-90ee2c9ab3b1",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "EHVh91iFr4F",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "328",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "4108",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "B.9.8 Utilisation correcte de l'outil indice - max points",
+        "origin": "dataValueSets",
+        "stableId": "40e99978-998c-452b-ab84-8c3ccc8e8589",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "aLi3GMO6dFo",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "330",
+            "type": "input"
+          }
+        }
+      }
+    },
+    {
+      "id": "4109",
+      "type": "inputMapping",
+      "attributes": {
+        "formula": null,
+        "name": "B.9.8 Utilisation correcte de l'outil indice - ver",
+        "origin": "dataValueSets",
+        "stableId": "d1a3858b-d071-4864-8289-4da9748094df",
+        "kind": "data_element"
+      },
+      "relationships": {
+        "externalRef": {
+          "data": {
+            "id": "zfg6pHlNLVU",
+            "type": "externalRef"
+          }
+        },
+        "input": {
+          "data": {
+            "id": "328",
+            "type": "input"
+          }
         }
       }
     }

--- a/mock-server/data/sets.json
+++ b/mock-server/data/sets.json
@@ -7388,21 +7388,24 @@
         "stableId": "88ff5257-e8ec-458d-acbb-9fd92a38ae8b"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "3996",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4019",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4020",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -7418,17 +7421,20 @@
         "stableId": "d779bf48-9862-4eb4-9c3a-586fcf1ae8c4"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "3997",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4021",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -7468,21 +7474,24 @@
         "stableId": "70c62d76-376c-4547-bb0e-ecca0e799725"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "3848",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "3849",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "3852",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -7498,21 +7507,24 @@
         "stableId": "a0783b4f-f983-463c-b14f-b4e6a1301647"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "3850",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "3851",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "3853",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -7528,21 +7540,24 @@
         "stableId": "2e4aa95d-40b8-4f92-8c63-bc95f9fd6a98"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "3854",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "3855",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "3856",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -7558,21 +7573,24 @@
         "stableId": "3e70a255-d16b-4b98-86b3-0f7d68d9e9ad"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "3857",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "3858",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "3863",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -7588,21 +7606,24 @@
         "stableId": "5a4a9ed8-0fd8-440a-bca6-3fef783c4c66"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "3859",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "3860",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "3864",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -7618,21 +7639,24 @@
         "stableId": "42bab832-a90f-466b-9464-b8cb6c1f254e"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "3861",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "3862",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "3865",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -7648,21 +7672,24 @@
         "stableId": "bb102ac5-50b3-4fb0-bd6e-a3679f61e69d"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "3866",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "3867",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "3878",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -7678,21 +7705,24 @@
         "stableId": "0af37adb-ccaf-4883-a3ff-609b379d6004"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "3868",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "3869",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "3879",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -7708,21 +7738,24 @@
         "stableId": "0c57d55b-bd3d-4226-9a52-21765c0e51ff"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "3870",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "3871",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "3880",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -7738,21 +7771,24 @@
         "stableId": "1e76535f-3dde-4dfe-a80c-467d2ebd0272"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "3872",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "3873",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "3881",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -7768,21 +7804,24 @@
         "stableId": "b5a58216-bc27-4bcd-b76e-84e3b02ae3de"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "3874",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "3875",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "3882",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -7798,21 +7837,24 @@
         "stableId": "493305b4-14fd-42b6-b920-b192a3e11e92"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "3876",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "3877",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "3883",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -7828,21 +7870,24 @@
         "stableId": "37f0ddf4-b6a1-49a9-9ff6-7560cd907b8f"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "3998",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4022",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4023",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -7858,17 +7903,20 @@
         "stableId": "79b146ad-3b6a-4054-9667-f22510a3c621"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "3999",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4024",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -7884,21 +7932,24 @@
         "stableId": "f95b7992-ad5a-4a10-b7c0-7b72479e1ffb"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "3972",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4008",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4015",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -7914,17 +7965,20 @@
         "stableId": "41b41a5d-2d31-47db-ad1c-cc943a5ef376"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "3973",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4009",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -7940,17 +7994,20 @@
         "stableId": "a953ddaf-9d21-490b-8c52-0026c7a9fa25"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "3974",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4010",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -7966,17 +8023,20 @@
         "stableId": "37cd0727-b715-44c0-9591-04248b42de46"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "3975",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4011",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -7992,21 +8052,24 @@
         "stableId": "3bc66320-5edc-4a74-8da6-cf96ceb842e2"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "3976",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4014",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4016",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -8022,17 +8085,20 @@
         "stableId": "78f3519d-6d51-4c6e-a1a4-af52c13cc3d8"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "3977",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4017",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -8048,17 +8114,20 @@
         "stableId": "fae70187-dd71-4c49-89ca-d91a602a02d3"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "3978",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4018",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -8074,21 +8143,24 @@
         "stableId": "865f94b7-dd66-46ca-b745-1b84ea5e4cd3"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4000",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4025",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4026",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -8104,17 +8176,20 @@
         "stableId": "92a6074c-535d-4fb0-b3b9-5407b66cb90d"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4001",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4027",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -8130,21 +8205,24 @@
         "stableId": "0b72fb08-1d8e-447a-b979-eab073f8742d"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4002",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4028",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4029",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -8160,17 +8238,20 @@
         "stableId": "f4cd0ba1-9a99-4717-8c62-ff6f11f7f4b8"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4003",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4030",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -8186,17 +8267,20 @@
         "stableId": "9dcc2d93-bbd5-465d-a60c-369e691fbb9c"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4004",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4031",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -8212,21 +8296,24 @@
         "stableId": "a3e1d112-c933-4769-9ce1-38d7acc79327"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4005",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4032",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4033",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -8242,21 +8329,24 @@
         "stableId": "e0fc8ef6-3a60-4d17-8771-f1790a2eb763"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4082",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4083",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4084",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -8272,21 +8362,24 @@
         "stableId": "72273128-33c6-4f05-b698-54ded60e7157"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4085",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4086",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4087",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -8302,17 +8395,20 @@
         "stableId": "78662736-5ee8-4a33-9322-8e6f4fe9845f"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4088",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4089",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -8328,17 +8424,20 @@
         "stableId": "57a61f77-ab0b-47e2-b730-966d6a3654c0"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4090",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4091",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -8354,17 +8453,20 @@
         "stableId": "078115ad-6e09-44db-a85c-deae5b120ac4"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4092",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4093",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -8380,17 +8482,20 @@
         "stableId": "dcabc92a-6c45-4874-ad28-fd9e2ff228b3"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4094",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4095",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -8406,17 +8511,20 @@
         "stableId": "8e57a999-662f-4dc7-a34c-10e16d0291e3"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4096",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4097",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -8432,17 +8540,20 @@
         "stableId": "95bb08cb-630b-4d1f-8ff7-0ffa663d40b3"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4098",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4099",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -8458,17 +8569,20 @@
         "stableId": "60f056f2-0142-4515-b10f-cd4475e751d8"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4100",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4101",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -8484,17 +8598,20 @@
         "stableId": "a4f93013-072f-4a4d-b91d-df97918e70ed"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4102",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4103",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -8510,17 +8627,20 @@
         "stableId": "88e17bfc-6f3d-4c78-971b-49614370638e"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4104",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4105",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -8536,17 +8656,20 @@
         "stableId": "a5a8ca8a-65fd-4282-9ad2-1eec3c04d229"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4106",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4107",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -8562,17 +8685,20 @@
         "stableId": "24e0d48b-0f60-4a9e-ba13-abcaae1f4c37"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4108",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4109",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -8588,21 +8714,24 @@
         "stableId": "9a78cce8-391e-4cb8-b804-ed0101b97060"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4113",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4114",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4115",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -8618,21 +8747,24 @@
         "stableId": "d7bed334-c36d-4409-b618-794003f5fbd3"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4110",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4111",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4112",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -8658,21 +8790,24 @@
         "stableId": "61d941fe-aff1-49c8-b21f-c0b582eef0c5"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4422",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4423",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4424",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -8688,17 +8823,20 @@
         "stableId": "4774949b-9a01-4a52-9082-4426003c4c44"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4425",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4426",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -8738,25 +8876,28 @@
         "stableId": "a2928d63-e047-4281-b907-4e6980bd762f"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4309",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4310",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4311",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5592",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -8788,21 +8929,24 @@
         "stableId": "5121ac02-ad4d-499b-9e04-2b8b59350c65"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4357",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4358",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4359",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -8828,21 +8972,24 @@
         "stableId": "7df275e3-66eb-484f-a776-de9f4670a348"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5006",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5007",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5016",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -8858,17 +9005,20 @@
         "stableId": "14492682-937f-44fa-a901-194227a9c416"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5008",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5009",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -8884,21 +9034,24 @@
         "stableId": "d60ba1f8-d6bf-4c3b-b88e-ef10201bedea"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4886",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4887",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4917",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -8914,17 +9067,20 @@
         "stableId": "c9713355-8d5e-4a18-b0b1-0235390ed7da"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4888",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4889",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -8940,17 +9096,20 @@
         "stableId": "f32c3747-3ad4-463e-8205-7b98c53eeaf6"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4890",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4891",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -8966,21 +9125,24 @@
         "stableId": "d6942711-7e4b-4ee0-9d77-1590764e02a0"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5010",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5011",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5017",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -8996,21 +9158,24 @@
         "stableId": "5b4ec6ac-51cb-4ed2-b2de-3ad1754350b1"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5012",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5013",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5018",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -9026,21 +9191,24 @@
         "stableId": "a2885d0c-61fa-4809-b79b-ddb52c4c43fc"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5019",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5020",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5053",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -9056,17 +9224,20 @@
         "stableId": "7825c02c-699f-4c96-a38f-4ce72fc367a4"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5021",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5022",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -9082,21 +9253,24 @@
         "stableId": "f52fae4d-69db-405c-87e6-00d9c68b0c2c"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4976",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4977",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5059",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -9112,17 +9286,20 @@
         "stableId": "bf3e38ae-fae0-4017-a60e-f8743cb64c87"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4978",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4979",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -9138,21 +9315,24 @@
         "stableId": "c048d53b-aad3-4cfe-9c98-be90c2fd84f9"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4981",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4982",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4997",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -9168,21 +9348,24 @@
         "stableId": "f934bc5c-2889-481e-b0a7-9e27da08df54"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4983",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4984",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4998",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -9198,17 +9381,20 @@
         "stableId": "1f8930be-aa0a-4313-9e03-80effea4a949"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4985",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4986",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -9224,21 +9410,24 @@
         "stableId": "92c59dfb-a87c-43dc-b6fd-7155de9a3e24"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4987",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4988",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4999",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -9254,17 +9443,20 @@
         "stableId": "5816892a-9834-4504-9de0-2c40d7720c5e"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4989",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4990",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -9280,21 +9472,24 @@
         "stableId": "59a21df6-6cfb-406f-94bc-1d379a7dee45"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4991",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4992",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5001",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -9310,17 +9505,20 @@
         "stableId": "c167cfdf-45ba-4725-ab1a-e3da786cc4eb"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4994",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5350",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -9336,17 +9534,20 @@
         "stableId": "71382c8a-ee99-4ba5-a062-5beedc8b9d2a"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5060",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5061",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -9362,21 +9563,24 @@
         "stableId": "8883563f-9cfe-449c-8f3f-5f77632fe28c"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4995",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4996",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5000",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -9392,21 +9596,24 @@
         "stableId": "935f6a42-3219-4376-abb8-9d1d4c096594"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5002",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5003",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5014",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -9422,21 +9629,24 @@
         "stableId": "326c5d84-be7c-4a9e-bc7e-a00ff0e08aca"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5004",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5005",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5015",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -9452,21 +9662,24 @@
         "stableId": "b2c6e408-1cbc-465a-9682-0aee7dd97639"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5023",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5024",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5054",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -9482,21 +9695,24 @@
         "stableId": "16078789-fb59-47fa-ae2e-423475010d6f"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5026",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5025",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5055",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -9512,21 +9728,24 @@
         "stableId": "6bc80e87-bcfc-430f-9b95-bf8031263ed4"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5027",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5028",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5056",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -9542,17 +9761,20 @@
         "stableId": "98119f7f-9a02-455e-92d1-7ecfe1fa3fc7"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5029",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5030",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -9568,17 +9790,20 @@
         "stableId": "068c6956-2964-45c2-b1f9-2efdb3f49454"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5031",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5032",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -9594,21 +9819,24 @@
         "stableId": "1b58ace2-4156-4fad-ac44-d1a95df058ca"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5033",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5034",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5057",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -9624,21 +9852,24 @@
         "stableId": "80f89029-69d4-4944-8f7c-57e146d81f18"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5035",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5036",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5058",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -9654,17 +9885,20 @@
         "stableId": "9abdc403-52dc-4bb4-9729-a01f5f27bb61"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5037",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5038",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -9680,17 +9914,20 @@
         "stableId": "128935d8-6cac-4434-a5dd-24c991cd076f"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5039",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5040",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -9706,17 +9943,20 @@
         "stableId": "1fae539d-2b4e-4682-9e09-4ef902fea325"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5041",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5042",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -9732,17 +9972,20 @@
         "stableId": "726e7aa0-8edf-4c9d-a2ef-2503e9614fa7"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5043",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5044",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -9758,17 +10001,20 @@
         "stableId": "4c5f394a-a881-41f5-a16d-ce642351a9fe"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5045",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5046",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -9784,17 +10030,20 @@
         "stableId": "2fd5f712-1a3d-464c-a432-eb3ac33e11c3"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5047",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5048",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -9810,17 +10059,20 @@
         "stableId": "599ab851-7adc-49e3-bf56-7490fd20eb9e"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5049",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5050",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -9836,17 +10088,20 @@
         "stableId": "a6e657cd-5fd8-4feb-83b2-90a3ceedb477"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5051",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5052",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -9862,21 +10117,24 @@
         "stableId": "be79e9f3-0222-4f49-84dd-b24dee0de6c7"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4825",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4826",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4832",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -9892,21 +10150,24 @@
         "stableId": "fecbaef6-6030-4928-8123-d952e410322f"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4821",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4824",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4831",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -9922,17 +10183,20 @@
         "stableId": "d52acb20-3515-413c-ad86-18b7b25b41ff"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4822",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4823",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -9948,21 +10212,24 @@
         "stableId": "d4d70f8c-8545-47b4-baf3-f5977ac5e171"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4835",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4836",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4844",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -9978,21 +10245,24 @@
         "stableId": "5f961ea5-efbc-4cd7-b73f-b9a1ca429b50"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4882",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4883",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4918",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -10008,17 +10278,20 @@
         "stableId": "07c95d69-24d9-4cba-a13d-6da2ad29dbfe"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4884",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4885",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -10034,21 +10307,24 @@
         "stableId": "16878bc3-4114-49d4-9acb-97fafad4adab"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4893",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4892",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4916",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -10064,21 +10340,24 @@
         "stableId": "8382379f-1be0-45c4-898c-b0c19d7ad49a"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4894",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4895",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4915",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -10094,17 +10373,20 @@
         "stableId": "525b1a90-a572-40a3-a09f-28dc7bb780ce"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4896",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4897",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -10120,17 +10402,20 @@
         "stableId": "e1357dde-25ab-4bc3-8727-e3e0966082aa"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4898",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4899",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -10146,17 +10431,20 @@
         "stableId": "91895cbc-eec5-45e4-9464-d3f1e66b60a2"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4900",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4901",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -10172,17 +10460,20 @@
         "stableId": "02258034-f11a-45f9-a173-590075d174f9"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4902",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4903",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -10198,17 +10489,20 @@
         "stableId": "1d3eedca-952a-4c92-b8dd-860965713d9f"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4904",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4905",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -10224,17 +10518,20 @@
         "stableId": "b491f34a-3d55-4894-a0c8-4edfb1dbf4d0"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4906",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4907",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -10250,17 +10547,20 @@
         "stableId": "56cf5cb0-b27e-4e2b-a2c9-bacf5fc8bef0"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4908",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4909",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -10276,17 +10576,20 @@
         "stableId": "ef15efee-e580-4f43-858c-f5305a820d95"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4910",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4911",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -10302,21 +10605,24 @@
         "stableId": "ea879b0a-e40d-43c5-bbf6-25aaec2e999a"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4833",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4834",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4843",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -10332,21 +10638,24 @@
         "stableId": "d51301db-56ed-4cde-a3b4-a7f60b1c534c"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4837",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4838",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4845",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -10362,17 +10671,20 @@
         "stableId": "0d6b0ef0-208b-42ea-9492-0c62612cde85"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4839",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4840",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -10388,17 +10700,20 @@
         "stableId": "f87030e1-71a2-4cd7-a92c-5f6ebd1c9ebf"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4841",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4842",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -10424,21 +10739,24 @@
         "stableId": "37549934-3781-4132-bbac-97c030afdeda"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5170",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5171",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5258",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -10454,17 +10772,20 @@
         "stableId": "c7d6587d-62db-4423-b6bb-f72c1756b6a5"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5172",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5173",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -10480,21 +10801,24 @@
         "stableId": "1bc331d2-4edc-4d60-b670-e3a719ff2071"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5174",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5175",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5259",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -10510,21 +10834,24 @@
         "stableId": "d3781bdf-08b9-405e-bda2-504da865cb4a"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5176",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5177",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5260",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -10540,21 +10867,24 @@
         "stableId": "c7a05ee3-4bc1-43f7-85b4-2a815a32b4d5"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5178",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5179",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5261",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -10570,21 +10900,24 @@
         "stableId": "6c3711de-fd83-46d2-81f1-aee627812139"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5180",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5181",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5262",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -10610,21 +10943,24 @@
         "stableId": "a33fc89f-fc9b-4ca7-85a7-466cf27e51bc"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5062",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5063",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5148",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -10640,17 +10976,20 @@
         "stableId": "5e6cbda9-bee5-4c42-9ae2-57cd56035a23"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5064",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5065",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -10666,17 +11005,20 @@
         "stableId": "e9c22977-54d7-4dc5-921b-05550515ba23"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5066",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5067",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -10692,17 +11034,20 @@
         "stableId": "87ae2b22-8301-4396-8d72-0f5b45bc9b62"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5068",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5069",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -10718,17 +11063,20 @@
         "stableId": "cf33a7e9-97f1-4cf2-b0ed-6688f4fe7261"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5070",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5071",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -10744,17 +11092,20 @@
         "stableId": "860c72ad-2d22-4b5e-80cd-aa6964a16151"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5073",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5072",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -10770,21 +11121,24 @@
         "stableId": "6a6ca851-c142-4a17-8463-6c80abdbcecc"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5074",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5075",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5149",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -10800,21 +11154,24 @@
         "stableId": "a1dc0ee4-562b-49a0-83c9-99a961f7fdc7"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5076",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5077",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5150",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -10830,17 +11187,20 @@
         "stableId": "3df47694-8b28-42db-ba89-dcc7ea3657ca"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5078",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5079",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -10856,17 +11216,20 @@
         "stableId": "981b2b94-4cc5-4900-bda9-d0f47317c947"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5080",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5081",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -10882,21 +11245,24 @@
         "stableId": "7c5ec0cf-b741-4727-9a0d-7ee2c5f19da5"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5082",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5083",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5151",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -10912,17 +11278,20 @@
         "stableId": "3d831371-0277-4e7e-a35c-56071d9256e2"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5084",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5085",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -10938,17 +11307,20 @@
         "stableId": "fd740b3f-fb2c-4876-8ad7-f85b2df482a1"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5086",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5087",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -10964,21 +11336,24 @@
         "stableId": "f375f6b3-b848-44e4-be0d-71e551d606b5"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5088",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5089",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5152",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -10994,17 +11369,20 @@
         "stableId": "a3633bc6-3dda-4447-ad4f-f19bd6042390"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5090",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5091",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -11020,17 +11398,20 @@
         "stableId": "2925adbb-7ddd-4b0a-b408-e5eec13e0703"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5092",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5093",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -11046,17 +11427,20 @@
         "stableId": "da13accd-fe9c-412f-b141-ff34a02dbd11"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5094",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5095",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -11072,21 +11456,24 @@
         "stableId": "e6425836-2af5-470b-8615-0a32071e7d95"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5096",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5097",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5153",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -11102,17 +11489,20 @@
         "stableId": "0f1295fb-1a8c-4717-ab10-8421cd53aae7"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5098",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5099",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -11128,17 +11518,20 @@
         "stableId": "08e20a75-cae8-4a2b-8343-3464d941fc70"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5100",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5101",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -11154,21 +11547,24 @@
         "stableId": "4e77b12c-6d9c-40b4-97e9-edab975ec86f"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5102",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5103",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5154",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -11184,17 +11580,20 @@
         "stableId": "c3a344c5-022b-48de-852b-75f3129392cf"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5104",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5105",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -11210,21 +11609,24 @@
         "stableId": "e27241e7-8eae-430e-8605-bb8ebadeb733"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5106",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5107",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5155",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -11240,17 +11642,20 @@
         "stableId": "59f07db8-efe1-421e-8337-9cf39d2ac01b"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5108",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5109",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -11266,17 +11671,20 @@
         "stableId": "519cee44-4020-4023-86eb-a411cdc5362a"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5110",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5111",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -11292,21 +11700,24 @@
         "stableId": "b75a23b7-915c-4b9f-a8bc-a12f19e29fee"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5112",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5113",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5156",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -11322,21 +11733,24 @@
         "stableId": "50894a83-64be-48db-8a27-e09218ee87de"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5114",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5115",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5157",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -11352,17 +11766,20 @@
         "stableId": "0cd91a39-59d1-4bd3-a9ea-dc91608a89b7"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5116",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5117",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -11378,17 +11795,20 @@
         "stableId": "24012b02-d51c-41c8-a422-8c2182ffcdfd"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5118",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5119",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -11404,21 +11824,24 @@
         "stableId": "27009e2c-97e5-4cdc-9a8f-e5338202b3f0"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5120",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5121",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5158",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -11434,17 +11857,20 @@
         "stableId": "1fd538ba-182f-4185-abfe-37a743b224d1"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5122",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5123",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -11460,17 +11886,20 @@
         "stableId": "cde78c04-11cb-495f-9a6d-eb7bfea4bd7d"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5124",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5125",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -11486,17 +11915,20 @@
         "stableId": "d0683df5-1320-4c76-9500-68bf7c1c089d"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5126",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5127",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -11512,21 +11944,24 @@
         "stableId": "fc881892-d22c-4306-9ebe-d37e332b8b5e"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5159",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5357",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5358",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -11542,17 +11977,20 @@
         "stableId": "82eb06ff-95ba-41b6-bfb4-c7fbe8594b3e"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5130",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5131",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -11568,17 +12006,20 @@
         "stableId": "ed4bf8ef-f6a8-4fb9-886a-d6625393dcd8"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5134",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5135",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -11594,17 +12035,20 @@
         "stableId": "7101377d-8395-46c9-80c8-7251dbc86697"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5136",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5137",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -11620,17 +12064,20 @@
         "stableId": "5fc610c1-ac42-46dc-bb63-8fa491c39a0f"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5138",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5139",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -11646,17 +12093,20 @@
         "stableId": "3953d3f4-4f69-4852-bd73-d27ab7a94ded"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5140",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5141",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -11672,17 +12122,20 @@
         "stableId": "bfcbe440-9214-4512-9d6c-71b2f9b884dc"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5142",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5143",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -11698,17 +12151,20 @@
         "stableId": "59e0a1a1-5b38-4689-b2fc-7ae432d18817"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5144",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5145",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -11724,17 +12180,20 @@
         "stableId": "ac0aae76-7e01-4500-99a6-3a2ab17bcf9a"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5146",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5147",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -11750,21 +12209,24 @@
         "stableId": "d45859a4-4fc4-4d3d-9ab2-eb314e475454"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4417",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4418",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4421",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -11780,17 +12242,20 @@
         "stableId": "05b5ccb1-3a74-46a5-b1f6-e7469b6d2a5e"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4419",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4420",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -11806,21 +12271,24 @@
         "stableId": "261f9507-85e6-4343-9325-8a41d4ddde2f"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "4813",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4814",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "4830",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -11836,21 +12304,24 @@
         "stableId": "05c02520-5d87-4d82-8335-0c0a653224e7"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5182",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5183",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5263",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -11866,21 +12337,24 @@
         "stableId": "2c1a0183-f9fd-426d-9f62-1adbb7048ded"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5184",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5185",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5264",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -11896,21 +12370,24 @@
         "stableId": "7e4d1127-af54-4c64-a0d7-c14f51413d08"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5186",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5187",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5265",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -11926,21 +12403,24 @@
         "stableId": "de3935f2-afad-4fbb-a480-7c4dabd12017"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5188",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5189",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5281",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -11956,21 +12436,24 @@
         "stableId": "181469b9-989b-47fb-aa47-54a87a8225b0"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5190",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5191",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5266",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -11986,21 +12469,24 @@
         "stableId": "62ef2355-a1b8-4d51-a400-44e42b6c10c1"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5192",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5193",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5267",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -12016,21 +12502,24 @@
         "stableId": "cfeb0f8a-f13a-4c5e-a586-60ddb3000e0a"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5194",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5195",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5268",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -12046,21 +12535,24 @@
         "stableId": "10c36e3e-516e-4ff5-9883-0754441fe934"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5196",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5197",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5269",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -12076,17 +12568,20 @@
         "stableId": "25cb058c-56b6-4559-a0b7-8114671ca12c"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5198",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5199",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -12102,17 +12597,20 @@
         "stableId": "3ef2a64d-f172-4cf9-a5b8-e557fa90de98"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5200",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5201",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -12128,17 +12626,20 @@
         "stableId": "f4cd10aa-7ceb-42a2-84c3-70101617a519"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5283",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5284",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -12154,21 +12655,24 @@
         "stableId": "3bd18013-67df-4a70-8d6f-569c374cb51e"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5208",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5209",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5282",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -12184,21 +12688,24 @@
         "stableId": "77ae0906-f59d-4b88-a1a9-9e679c3a64cb"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5210",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5211",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5272",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -12214,21 +12721,24 @@
         "stableId": "c8a99f57-0fe7-4df1-8651-2cf9d849d988"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5212",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5213",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5353",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -12244,21 +12754,24 @@
         "stableId": "1e115b93-6464-4bda-bad1-3454e50e64b5"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5214",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5215",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5273",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -12274,21 +12787,24 @@
         "stableId": "6eb7344c-2535-4e76-bb8f-289fb646711d"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5216",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5217",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5274",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -12304,17 +12820,20 @@
         "stableId": "ed9fb0ae-d754-4184-a1c5-f03146de0c60"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5218",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5219",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -12330,21 +12849,24 @@
         "stableId": "6df2e278-a4fa-430d-a762-bb020b3c7293"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5206",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5207",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5271",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -12360,21 +12882,24 @@
         "stableId": "bbe94f27-a289-4b85-874d-1dca927542a2"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5220",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5221",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5275",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -12390,17 +12915,20 @@
         "stableId": "358f0db8-c825-4e40-82be-d62bb7c4e4ba"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5222",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5223",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -12416,17 +12944,20 @@
         "stableId": "d5f7ec77-342a-4425-a700-1c584d62741a"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5224",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5225",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -12442,21 +12973,24 @@
         "stableId": "0cc8a759-bd98-4a01-8586-e35099f7d83a"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5226",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5227",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5276",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -12472,17 +13006,20 @@
         "stableId": "c15e9249-97c2-4a6e-9020-43f836cf2e22"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5228",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5229",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -12498,17 +13035,20 @@
         "stableId": "2016f9f6-e28a-475f-b807-72b2f9e8109b"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5230",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5231",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -12524,21 +13064,24 @@
         "stableId": "95eb1789-53d3-479b-a135-eb4cb5839b08"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5232",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5233",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5277",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -12554,17 +13097,20 @@
         "stableId": "c36a76c0-2ca4-476c-bcfa-8f79a67364e7"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5234",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5235",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -12580,21 +13126,24 @@
         "stableId": "867f6a90-f518-4df5-8cb7-ffcf186f62aa"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5236",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5237",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5278",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -12610,21 +13159,24 @@
         "stableId": "0f1f64da-7c01-435c-96a2-508818e07f62"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5238",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5239",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5279",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -12640,21 +13192,24 @@
         "stableId": "fec0ac5a-2d53-4d3e-a56b-958774116a88"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5240",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5241",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5280",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -12670,17 +13225,20 @@
         "stableId": "3a81c3c7-d1cb-45bc-929f-9c43f1ec87e2"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5242",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5243",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -12696,17 +13254,20 @@
         "stableId": "52ef8424-46ac-4c07-aed4-0a468ff3ce5c"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5244",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5245",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -12722,17 +13283,20 @@
         "stableId": "d7cbaf67-4894-4373-a22c-3968e34a8ffa"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5246",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5247",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -12748,17 +13312,20 @@
         "stableId": "dbe05d9c-99fb-47ec-866c-ca185bca6ef5"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5248",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5249",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -12774,17 +13341,20 @@
         "stableId": "1244702a-9001-4426-b029-6b3bcda0ace8"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5250",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5251",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -12800,17 +13370,20 @@
         "stableId": "92a1b397-9a79-4023-babe-5e922b32bcb1"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5252",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5253",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -12826,17 +13399,20 @@
         "stableId": "f11d5c79-d962-4da7-9e1d-90eed0806066"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5254",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5255",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -12852,17 +13428,20 @@
         "stableId": "5ecf2e71-cdf1-4ce3-ba5a-7014dc31c892"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5256",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5257",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -12888,21 +13467,24 @@
         "stableId": "5794f177-8ba2-4587-ba2d-2d455e88cef0"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5286",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5287",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5290",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -12918,21 +13500,24 @@
         "stableId": "53e110a7-18f6-49e1-a7e3-91dfe4b96494"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5291",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5292",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5339",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -12948,17 +13533,20 @@
         "stableId": "3b141c71-eade-41b3-ae45-32f76d56777d"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5293",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5294",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -12974,21 +13562,24 @@
         "stableId": "385bb009-ccd0-404f-a163-b653efbfc312"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5295",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5296",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5340",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -13004,17 +13595,20 @@
         "stableId": "1aca3a4d-5053-46b2-88fc-948fdebc12c1"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5297",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5298",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -13030,21 +13624,24 @@
         "stableId": "c5e6c974-068c-4891-9c3e-adcaffd96370"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5299",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5300",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5341",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -13060,21 +13657,24 @@
         "stableId": "20663390-1222-44df-ad60-3ec66736bf5c"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5301",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5302",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5342",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -13090,21 +13690,24 @@
         "stableId": "eee0469b-9953-4061-8abd-8fd3e2250952"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5303",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5304",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5343",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -13120,17 +13723,20 @@
         "stableId": "0700a153-87c4-4067-b2dc-629ecc0f6603"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5305",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5306",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -13146,17 +13752,20 @@
         "stableId": "65a92b59-a161-4f22-9bfb-338edc476327"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5307",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5308",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -13172,21 +13781,24 @@
         "stableId": "ea674550-8324-4d87-a451-c09e7485770b"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5309",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5310",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5344",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -13202,21 +13814,24 @@
         "stableId": "182fe8e3-de3b-48ba-8867-6415dc16f11b"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5311",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5312",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5345",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -13232,21 +13847,24 @@
         "stableId": "63e493ce-24ae-4d01-904f-97c00442d4cd"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5313",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5314",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5346",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -13262,21 +13880,24 @@
         "stableId": "69d1a37e-1b05-42ce-9a60-c1afa2dc5989"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5315",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5316",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5347",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -13292,17 +13913,20 @@
         "stableId": "b0ba9ace-4311-40e8-bff0-cf2eaf62f3d2"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5317",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5318",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -13318,21 +13942,24 @@
         "stableId": "cf97e547-02bc-45e9-8755-a55bd80f94d4"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5319",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5320",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5348",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -13348,21 +13975,24 @@
         "stableId": "81b5470a-c067-44e6-ad1a-153b9768564f"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5321",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5322",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5349",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -13378,17 +14008,20 @@
         "stableId": "c786a6ca-89b0-4183-bd86-0ad47c32b237"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5323",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5324",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -13404,17 +14037,20 @@
         "stableId": "bfc8df3e-b9ea-465d-b36e-084595f6602e"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5325",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5326",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -13430,17 +14066,20 @@
         "stableId": "bb19dcf8-fc45-4522-95ae-fdc09dcc8f7d"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5327",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5328",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -13456,17 +14095,20 @@
         "stableId": "d9405265-2c66-4deb-b967-0bcc377860f2"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5329",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5330",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -13482,17 +14124,20 @@
         "stableId": "3c5f435f-78a2-4b86-b605-4fc23ceb8565"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5331",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5332",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -13508,17 +14153,20 @@
         "stableId": "59400b3f-7ab7-4931-97cb-d0383ffccf44"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5333",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5334",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -13534,17 +14182,20 @@
         "stableId": "722f05ab-0c71-4f62-9cae-326da0f24bcc"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5335",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5336",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -13560,17 +14211,20 @@
         "stableId": "6f6b5797-a220-4a41-a68d-9507a044b11f"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5337",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5338",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -13586,21 +14240,24 @@
         "stableId": "675a09f5-9334-4f3e-9449-a88345c5d96a"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5204",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5205",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5270",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     },
@@ -13632,17 +14289,20 @@
         "stableId": "880c3d73-1ea3-474b-8032-47b06346c89f"
       },
       "relationships": {
-        "inputs": {
+        "inputMappings": {
           "data": [
             {
               "id": "5393",
-              "type": "input"
+              "type": "inputMapping"
             },
             {
               "id": "5394",
-              "type": "input"
+              "type": "inputMapping"
             }
           ]
+        },
+        "formulaMappings": {
+          "data": []
         }
       }
     }


### PR DESCRIPTION
This changes the payload of the `/api/sets/1` to also include inputMappings, and the dhis reference of such a mapping. The payload of the show will now look like this:

``` json
{
  "data": {
    "id": "295",
    "type": "set",
    "attributes": {
      "name": "COSPRO - A.1 - Application mesure gratuité",
      "description": "A.1 - Faire appliquer les dispositions de l’arrêté du Gouverneur sur la gratuité dans son régime de gestion",
      "frequency": "quarterly",
      "kind": "single",
      "includeMainOrgunit": false,
      "loopOverComboExtId": null,
      "dataElementGroupExtRef": "todo"
    },
    "relationships": {
      "simulationOrgUnit": {
        "data": {
          "id": "uPemYZa36Ug",
          "type": "simulationOrgUnit"
        }
      },
      "orgUnitGroups": {
        "data": [
          {
            "id": "HSY3jXSf44P",
            "type": "orgUnitGroup"
          }
        ]
      },
      "orgUnitGroupSets": {
        "data": [
        ]
      },
      "inputs": {
        "data": [
          {
            "id": "328",
            "type": "input"
          },
          {
            "id": "330",
            "type": "input"
          },
          {
            "id": "332",
            "type": "input"
          }
        ]
      },
      "topicFormulas": {
        "data": [
          {
            "id": "2294",
            "type": "topicFormula"
          },
          {
            "id": "2295",
            "type": "topicFormula"
          },
          {
            "id": "2296",
            "type": "topicFormula"
          },
          {
            "id": "2298",
            "type": "topicFormula"
          },
          {
            "id": "2297",
            "type": "topicFormula"
          }
        ]
      },
      "topics": {
        "data": [
          {
            "id": "1466",
            "type": "topic"
          }
        ]
      }
    }
  },
  "included": [
    {
      "id": "328",
      "type": "input",
      "attributes": {
        "name": "Reached",
        "shortName": "Palier Atteint"
      }
    },
    {
      "id": "330",
      "type": "input",
      "attributes": {
        "name": "Max Points",
        "shortName": "Max Points"
      }
    },
    {
      "id": "332",
      "type": "input",
      "attributes": {
        "name": "Available Budget",
        "shortName": "Budget Disponible"
      }
    },
    {
      "id": "HSY3jXSf44P",
      "type": "orgUnitGroup",
      "attributes": {
        "value": "CosPro",
        "id": "HSY3jXSf44P",
        "name": "CosPro",
        "displayName": "CosPro"
      }
    },
    {
      "id": "1466",
      "type": "topic",
      "attributes": {
        "code": "cospro_a_1_1",
        "name": "COSPRO - A.1.1 - 100% d'écoles et COPAs de son ressort  sont informés et disposent  des arrêtés sur les mesures de gratuité des frais scolaires",
        "shortName": "COSPRO - A.1.1 - all école/COPA gratuit",
        "createdAt": "2019-07-04T07:00:15.436Z",
        "updatedAt": "2019-07-04T07:00:15.436Z",
        "stableId": "5794f177-8ba2-4587-ba2d-2d455e88cef0"
      },
      "relationships": {
        "inputMappings": {
          "data": [
            {
              "id": "5286",
              "type": "inputMapping"
            },
            {
              "id": "5287",
              "type": "inputMapping"
            },
            {
              "id": "5290",
              "type": "inputMapping"
            }
          ]
        },
        "formulaMappings": {
          "data": [
          ]
        }
      }
    },
    {
      "id": "5286",
      "type": "inputMapping",
      "attributes": {
        "formula": null,
        "name": "COSPRO - A.1.1 - Points Maximum",
        "origin": "dataValueSets",
        "stableId": "b23afbee-f492-4882-b606-b783be96cfe5",
        "kind": "data_element"
      },
      "relationships": {
        "externalRef": {
          "data": {
            "id": "bhrcdyzOuf7",
            "type": "externalRef"
          }
        },
        "input": {
          "data": {
            "id": "330",
            "type": "input"
          }
        }
      }
    },
    {
      "id": "5287",
      "type": "inputMapping",
      "attributes": {
        "formula": null,
        "name": "COSPRO - A.1.1- Palier atteint - vérifié",
        "origin": "dataValueSets",
        "stableId": "1123d85c-b814-476f-b69f-91ae902b5487",
        "kind": "data_element"
      },
      "relationships": {
        "externalRef": {
          "data": {
            "id": "gL9TlPEnGV6",
            "type": "externalRef"
          }
        },
        "input": {
          "data": {
            "id": "328",
            "type": "input"
          }
        }
      }
    },
    {
      "id": "5290",
      "type": "inputMapping",
      "attributes": {
        "formula": null,
        "name": "COSPRO - Budget Disponible -  A.1.1 - 100% d'écoles et COPAs de son ressort  sont informés et disposent  des arrêtés sur les mesures de gratuité des frais scolaires",
        "origin": "dataValueSets",
        "stableId": "19511cd9-f636-49da-9dbe-763e78b52fea",
        "kind": "data_element"
      },
      "relationships": {
        "externalRef": {
          "data": {
            "id": "W5WGooDpDyr",
            "type": "externalRef"
          }
        },
        "input": {
          "data": {
            "id": "332",
            "type": "input"
          }
        }
      }
    }
  ]
}
```

A set already includes the `inputs`, a topic will include the `input_mappings` which have a link back to the `input` so with those two combined we should be able to fill up the matrix.

Each `input_mapping` also has an `external_ref` relationship which contains the link to the DHIS element.

``` json
    {
      "id": "5287",
      "type": "inputMapping",
      "attributes": {
        "formula": null,
        "name": "COSPRO - A.1.1- Palier atteint - vérifié",
        "origin": "dataValueSets",
        "stableId": "1123d85c-b814-476f-b69f-91ae902b5487",
        "kind": "data_element"
      },
      "relationships": {
        "externalRef": {
          "data": {
            "id": "gL9TlPEnGV6",
            "type": "externalRef"
          }
        },
        "input": {
          "data": {
            "id": "328",
            "type": "input"
          }
        }
      }
    }
```