### PR TITLE
feat: Allow to select orgunit to display within the invoices of the simulation

### DIFF
--- a/src/containers/SimulationContainer/index.js
+++ b/src/containers/SimulationContainer/index.js
@@ -42,7 +42,13 @@ class SimulationContainer extends Component {
       }, 2000);
     }
 
-    if (this.props.location.search !== prevProps.location.search) {
+    const search = queryString.parse(this.props.location.search);
+    const previousSearch = queryString.parse(prevProps.location.search);
+
+    if (
+      previousSearch.periods !== search.periods ||
+      previousSearch.orgUnit !== search.orgUnit
+    ) {
       this.fetchSimulation();
     }
   }


### PR DESCRIPTION
We will probably change that at some point... but at least it makes the manager usable/on par with the legacy.

![image](https://user-images.githubusercontent.com/371692/93770092-061bf200-fc1c-11ea-8f38-dd352ccdcbf2.png)

Performance wise, it's still slow, I prevented the redownload of the jsons but not perfect.
I would move the download in the container at the same place where download the status.