### PR TITLE
Use token and url from dhis2 datastore

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,46 @@ It will become the new frontend to the existing [Hesabu API](https://github.com/
 
 # Development
 
+## create a .env
+
+### .env to point to a prod dhis2 and prod hesabu api
+
+```bash
+REACT_APP_DHIS2_URL=
+REACT_APP_USER=
+REACT_APP_PASSWORD=
+```
+
+### .env to point to a prod dhis2 and local hesabu api
+
+```bash
+REACT_APP_DHIS2_URL=
+REACT_APP_USER=
+REACT_APP_PASSWORD=
+
+REACT_APP_API_URL=http://localhost:3001/api
+REACT_APP_API_TOKEN=<<your_project_token>>
+```
+
+## .env to point to a play dhis2 and mock hesabu api
+
+```bash
+REACT_APP_DHIS2_URL=https://play.dhis2.org/2.30
+REACT_APP_USER=admin
+REACT_APP_PASSWORD=district
+
+REACT_APP_API_URL=http://localhost:4567/api
+REACT_APP_API_TOKEN=<<unused>>
+```
+
+Don't forget to start the mock server (ruby required)
+
+```bash
+cd ../mock-server
+bundle install
+bundle exec ruby app.rb
+```
+
 ## Getting started
 
 Run the app. This a [CRA](https://github.com/facebook/create-react-app) app, so all standard commands works as expected.
@@ -47,4 +87,6 @@ If you want to avoid this hook, run with `HUSKY_SKIP_HOOKS=1`, and run `yarn for
 
 # Deploy
 
-TODO
+- except for debugging purpose don't deploy individually, or from your laptop.
+- the cra app is build based on the `development` branch by github actions and published to s3
+- the deployment of this s3 artefact is done via a rake task in the `orbf2` [repository](https://github.com/blsq/orbf2) to target all the dhis2 configured in the database.

--- a/src/actions/api.js
+++ b/src/actions/api.js
@@ -1,11 +1,12 @@
 import wretch from "wretch";
 import { RECEIVE_TOKEN, RECEIVE_TOKEN_ERROR } from "../constants/types";
-
+import store from "../store";
 import i18n from "../lib/i18n";
 
-export const receiveToken = token => ({
+export const receiveToken = ({ token, url }) => ({
   type: RECEIVE_TOKEN,
   token,
+  url,
 });
 
 export const receiveTokenError = error => ({
@@ -14,18 +15,20 @@ export const receiveTokenError = error => ({
 });
 
 export const externalApi = () => {
-  // TODO: Fetch token from Dhis instead of baking it in at compile time
-  // const state = store.getState();
-  // const { token } = state.api;
-  const token = process.env.REACT_APP_API_TOKEN;
+  const state = store.getState();
+  const { token, url } = state.api;
+
+  const finalUrl = process.env.REACT_APP_API_URL || `${url}/api`;
+  const finalToken = process.env.REACT_APP_API_TOKEN || token;
+
   const headers = {
     "Accept-Language": i18n.language,
     Accept: "application/vnd.api+json;version=2",
-    "X-Token": token,
+    "X-Token": finalToken,
   };
 
   return wretch()
-    .url(process.env.REACT_APP_API_URL)
+    .url(finalUrl)
     .headers(headers)
     .options({ encoding: "same-origin", headers });
 };

--- a/src/lib/Api.js
+++ b/src/lib/Api.js
@@ -12,6 +12,7 @@ class Api {
     this.user = process.env.REACT_APP_USER;
     this.password = process.env.REACT_APP_PASSWORD;
     this.ignoredStores = [""];
+    this.initialize();
   }
 
   /**
@@ -49,12 +50,11 @@ class Api {
     return this;
   }
 
-  projectToken = () => {
+  projectTokenAndUrl = () => {
     return getInstance().then(d2 => {
-      return d2.dataStore.get("blsq-dataviz").then(namespace => {
-        console.log(namespace);
-        return namespace.get(window.tokenName).then(value => {
-          return value["token"];
+      return d2.dataStore.get("hesabu").then(namespace => {
+        return namespace.get("hesabu").then(value => {
+          return value;
         });
       });
     });

--- a/src/lib/Api.js
+++ b/src/lib/Api.js
@@ -53,9 +53,7 @@ class Api {
   projectTokenAndUrl = () => {
     return getInstance().then(d2 => {
       return d2.dataStore.get("hesabu").then(namespace => {
-        return namespace.get("hesabu").then(value => {
-          return value;
-        });
+        return namespace.get("hesabu");
       });
     });
   };

--- a/src/lib/TokenProvider.js
+++ b/src/lib/TokenProvider.js
@@ -1,29 +1,33 @@
+import React from "react";
 import { Component } from "react";
 import { connect } from "react-redux";
 import { receiveToken, receiveTokenError } from "../actions/api";
-
+import SectionLoading from "../components/Shared/SectionLoading";
 import Api from "./Api";
 
 class TokenProvider extends Component {
   componentDidMount() {
-    if (false) {
-      Api.projectToken()
-        .then(token => {
-          this.props.receiveToken(token);
-        })
-        .catch(e => {
-          this.props.receiveTokenError(e.message);
-        });
-    }
+    Api.projectTokenAndUrl()
+      .then(config => {
+        this.props.receiveToken(config);
+      })
+      .catch(e => {
+        this.props.receiveTokenError(e.message);
+      });
   }
 
   render() {
-    return this.props.children;
+    if (this.props.token) {
+      return this.props.children;
+    } else {
+      return <SectionLoading />;
+    }
   }
 }
 
 const mapStateToProps = state => ({
   token: state.api.token,
+  url: state.api.url,
   errored: !!state.api.error,
 });
 

--- a/src/reducers/api.js
+++ b/src/reducers/api.js
@@ -9,7 +9,7 @@ function api(
 ) {
   switch (action.type) {
     case RECEIVE_TOKEN:
-      return { ...state, token: action.token };
+      return { ...state, token: action.token, url: action.url };
     case RECEIVE_TOKEN_ERROR:
       return { ...state, error: action.error };
     default:


### PR DESCRIPTION
- don't render the app until we have the token show a spinner
- take the url and token from datastore (still allow to override them via env variables for development)
- adapt the readme to show all variants for .env