### PR TITLE
Handle AND OR and try to keep original formating

### DIFF
--- a/src/components/Formula/utils.js
+++ b/src/components/Formula/utils.js
@@ -22,6 +22,8 @@ const knownFunctions = new Set([
   "-",
   "/",
   "*",
+  "and",
+  "or",
 ]);
 
 function isNumeric(str) {
@@ -34,7 +36,9 @@ function isNumeric(str) {
 export const dependencies = expression => {
   const tokens = expression
     .toLowerCase()
-    .split(/[%({}\(\)\+\-\*\,/=<>]/gi)
+    .split(" and ")
+    .flatMap(s => s.split(" or "))
+    .flatMap(s => s.split(/[%({}\(\)\+\-\*\,/=<>]/gi))
     .map(s => s.trim());
 
   const tokensWithoutFunctionsAndConstants = tokens.filter(
@@ -55,7 +59,9 @@ export const formulasToMermaid = (formulas, parent) => {
   for (const formula of formulas) {
     graph.push(`class ${formula.code} current`);
     graph.push(
-      `${formula.code}${shape[0]}"${formula.code} <br> ${formula.expression}"${shape[1]}`,
+      `${formula.code}${shape[0]}"${
+        formula.code
+      } <br> ${formula.expression.split("\n").join("<br>")}"${shape[1]}`,
     );
   }
   graph.push("classDef current fill:#f96;");

--- a/src/components/Formula/utils.test.js
+++ b/src/components/Formula/utils.test.js
@@ -25,6 +25,20 @@ describe("formula utils", () => {
     expect(dependencies(formula2.expression)).toEqual(["claimed", "verified"]);
   });
 
+  it("dependencies AND OR", () => {
+    expect(
+      dependencies(`if(denomination==0,
+        if(indicator_parameter_1_is_null ==1 AND indicator_parameter_2_is_null==1,0,1),
+        if(indicator_denominator_is_null ==1 OR indicator_parameter_1_is_null ==1,0,1)
+        )`),
+    ).toEqual([
+      "denomination",
+      "indicator_parameter_1_is_null",
+      "indicator_parameter_2_is_null",
+      "indicator_denominator_is_null",
+    ]);
+  });
+
   it("formulasToMermaid", () => {
     expect(formulasToMermaid(formulas, undefined)).toEqual(
       `


### PR DESCRIPTION
This equation was breaking the expression rendering and once fixed was on a single line
It's now rendered as follow

![image](https://user-images.githubusercontent.com/371692/95176915-ccbbb880-07bd-11eb-8288-e1b3690b84e8.png)

in the bad news you can't put all what you want as html in the node label