### PR TITLE
Add links between the compound page and sets

### DIFF
--- a/src/components/Compounds/Compound/index.js
+++ b/src/components/Compounds/Compound/index.js
@@ -6,7 +6,7 @@ import {
   makeStyles,
   CircularProgress,
 } from "@material-ui/core";
-import { useHistory, withRouter } from "react-router-dom";
+import { useHistory, withRouter, Link } from "react-router-dom";
 import PropTypes from "prop-types";
 import { useTranslation } from "react-i18next";
 import TopBar from "../../Shared/TopBar";
@@ -15,7 +15,7 @@ import SideSheet from "../../SideSheet";
 import SidebarBlock from "../../Shared/SidebarBlock";
 import { formattedName } from "../../../utils/textUtils";
 import FiltersToggleBtn from "../../FiltersToggleBtn";
-import Formulas from "../../../components/Formula/Formulas";
+import Formulas from "../../Formula/Formulas";
 
 const Transition = React.forwardRef(function Transition(props, ref) {
   return <Slide direction="up" ref={ref} {...props} />;
@@ -48,7 +48,6 @@ const Compound = props => {
     sets,
   } = props;
   const { t } = useTranslation();
-  const filteredSets = (sets || []).filter(s => s);
 
   return (
     <Dialog
@@ -74,18 +73,32 @@ const Compound = props => {
           <Formulas formulas={formulas} parent={compound} />
         </PageContent>
         <SideSheet
+          variant="big"
           title={t("compound.sidesheet.title")}
           open={sideSheetOpen}
           onClose={onSideSheetClose}
         >
-          {!!filteredSets.length && (
-            <SidebarBlock title={formattedName(t("resources.set_plural"))}>
-              <span>{filteredSets.map(set => set?.id)}</span>
-            </SidebarBlock>
-          )}
           {frequency && (
             <SidebarBlock title={formattedName(t(`compound.frequency`))}>
               {t(`periodicity.${frequency}`)}
+            </SidebarBlock>
+          )}
+          {sets && (
+            <SidebarBlock title={formattedName(t(`compound.sets`))}>
+              {sets
+                .sort((a, b) => a.name.localeCompare(b.name))
+                .map(set => (
+                  <div key={`set-${set.id}`}>
+                    <Typography
+                      component={Link}
+                      to={`/sets/${set.id}`}
+                      color="inherit"
+                      title={set.frequency}
+                    >
+                      {set.name}
+                    </Typography>
+                  </div>
+                ))}
             </SidebarBlock>
           )}
         </SideSheet>

--- a/src/components/Compounds/CompoundsListItem/index.js
+++ b/src/components/Compounds/CompoundsListItem/index.js
@@ -9,9 +9,8 @@ import { formattedName } from "../../../utils/textUtils";
 
 const CompoundsListItem = props => {
   const classes = styles();
-  const { name, id, formulas, frequency } = props;
+  const { name, id, formulas, frequency, sets } = props;
   const { t } = useTranslation();
-
   return (
     <div className={classes.root}>
       <Typography
@@ -26,8 +25,22 @@ const CompoundsListItem = props => {
         <Typography component="li" variant="body2">
           {formattedName(t(`periodicity.${frequency}`))}
         </Typography>
-        <Typography component="li" variant="body2">
+        <Typography
+          component="li"
+          variant="body2"
+          title={formulas.map(s => s.code).join("\n")}
+        >
           {formulas.length} {t("resources.formula", { count: formulas.length })}
+        </Typography>
+        <Typography
+          component="li"
+          variant="body2"
+          title={sets
+            .map(s => s.name)
+            .sort()
+            .join("\n")}
+        >
+          {formulas.length} {t("resources.set", { count: sets.length })}
         </Typography>
       </HorizontalBulletList>
     </div>

--- a/src/components/Shared/Mermaid.js
+++ b/src/components/Shared/Mermaid.js
@@ -43,7 +43,12 @@ class Mermaid extends Component {
       return <div>Loading...</div>;
     }
 
-    return <div dangerouslySetInnerHTML={{ __html: this.state.svg }} />;
+    return (
+      <div
+        dangerouslySetInnerHTML={{ __html: this.state.svg }}
+        style={{ width: "100%" }}
+      />
+    );
   }
 }
 

--- a/src/lib/translations/en.js
+++ b/src/lib/translations/en.js
@@ -25,10 +25,11 @@ export default {
         mockedValues: "Mocked values",
       },
       compound: {
-        frequency: "Fréquency",
+        frequency: "Frequency",
         sidesheet: {
           title: "Compound info",
         },
+        sets: "Sets",
       },
       noData: "N/A",
       emptySection: {

--- a/src/lib/translations/fr.js
+++ b/src/lib/translations/fr.js
@@ -28,6 +28,7 @@ export default {
         sidesheet: {
           title: "Compound info",
         },
+        sets: "Sets",
       },
       noData: "N/D",
       emptySection: {


### PR DESCRIPTION
REQUIRES : https://github.com/BLSQ/orbf2/pull/209

in the list show the number of sets, and tooltip with sets names

![Selection_475](https://user-images.githubusercontent.com/371692/95576732-398ab900-0a31-11eb-9b43-d9af8d8a5442.png)

in the side sheet show links to packages

![Selection_474](https://user-images.githubusercontent.com/371692/95576722-37285f00-0a31-11eb-9d54-14af0d59c27d.png)
